### PR TITLE
Hotfix v0.2.1: Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Create release archive
         run: |
           mkdir -p release
-          cp -r dist release/
+          cp index.js release/
           cp package.json release/
           cp README.md release/ 2>/dev/null || echo "No README.md found"
           cd release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-super-table",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "directus:extension": {
     "type": "layout",


### PR DESCRIPTION
## 🔧 Hotfix v0.2.1

### Problem
The release workflow for v0.2.0 failed because it was trying to copy a `dist/` directory that doesn't exist. The Directus extension actually builds to `index.js` in the root directory.

### Solution
- Fixed the release workflow to copy `index.js` instead of `dist/`
- Bumped version to 0.2.1

### Changes
- Updated `.github/workflows/release.yml` to use correct build output
- Updated version in `package.json` to 0.2.1

### Testing
- The build process creates `index.js` in the root
- This file is needed for the extension to work

This hotfix will allow the release workflow to complete successfully.