### PR TITLE
Hotfix v0.2.1: Merge back to develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Create release archive
         run: |
           mkdir -p release
-          cp -r dist release/
+          cp index.js release/
           cp package.json release/
           cp README.md release/ 2>/dev/null || echo "No README.md found"
           cd release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-super-table",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "directus:extension": {
     "type": "layout",


### PR DESCRIPTION
## Merge Hotfix v0.2.1 to develop

Merging the hotfix from main back to develop to keep branches in sync.

### Changes from Hotfix v0.2.1:
- Fixed release workflow to use `index.js` instead of `dist/`
- Bumped version to 0.2.1

Part of Git Flow process - hotfixes must be merged to both main and develop.