### PR TITLE
Hotfix v0.2.8: Prepare for npm publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Super Layout Table Extension will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.8] - 2025-08-22
+
+### Added
+- Published to npm registry as `directus-extension-super-table`
+- LICENSE file (MIT)
+- Complete package.json metadata for npm publishing
+- Repository, homepage, and bug tracking URLs
+
+### Changed
+- Updated package.json with proper npm configuration
+- Main entry point now correctly points to dist/index.js
+
 ## [0.2.7] - 2025-08-22
 
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 smartlabs AT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,32 @@
 {
   "name": "directus-extension-super-table",
-  "version": "0.2.7",
+  "version": "0.2.8",
+  "description": "A powerful and feature-rich table layout extension for Directus 11+ with inline editing, quick filters, and manual sorting",
+  "keywords": [
+    "directus",
+    "directus-extension",
+    "directus-layout",
+    "table",
+    "inline-editing",
+    "super-table"
+  ],
+  "homepage": "https://github.com/smartlabsAT/directus-super-table#readme",
+  "bugs": {
+    "url": "https://github.com/smartlabsAT/directus-super-table/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/smartlabsAT/directus-super-table.git"
+  },
+  "license": "MIT",
+  "author": "smartlabs AT",
   "type": "module",
+  "files": [
+    "index.js",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "index.js",
   "directus:extension": {
     "type": "layout",
     "path": "index.js",


### PR DESCRIPTION
## Summary
- Added MIT LICENSE file
- Added complete npm metadata to package.json
- Configured package for npm registry publishing

## Changes
- Version bumped to 0.2.8
- Added description, keywords, repository, homepage, and bug tracking URLs
- Configured files array to include only necessary files in npm package
- Added LICENSE file

## npm Package
Successfully published as `directus-extension-super-table@0.2.8`

Users can now install via:
```bash
npm install directus-extension-super-table
# or
pnpm add directus-extension-super-table
```

## Type
Hotfix