### PR TITLE
Fix: Manual sort column disappearing during column resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Super Layout Table Extension will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.10] - 2025-08-30
+
+### Fixed
+- Fixed manual sort column disappearing during column resizing operations
+- Removed loading state dependency from sortAllowed computed property to prevent temporary hiding of manual sort handles
+- Manual sort column now remains consistently visible during all table interactions
+
+### Technical Details
+- Issue #27: Manual sort handlers would temporarily disappear when resizing columns
+- Root cause: `sortAllowed` computed property included `!loading.value` condition
+- Solution: Simplified `sortAllowed` to only check for sort field existence and readonly state
+
 ## [0.2.8] - 2025-08-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-super-table",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "A powerful and feature-rich table layout extension for Directus 11+ with inline editing, quick filters, and manual sorting",
   "keywords": [
     "directus",

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -398,8 +398,9 @@ const sortFieldName = computed(() => {
 });
 
 // Manual sort is allowed when there's a sort field and not readonly
+// Note: We don't check loading state to prevent manual sort column from disappearing during operations
 const sortAllowed = computed(() => {
-  return !!sortFieldName.value && !readonly.value && items.value?.length > 0 && !loading.value;
+  return !!sortFieldName.value && !readonly.value;
 });
 
 // Use pagination composable


### PR DESCRIPTION
## Summary
- Fixes issue #27 where the manual sort column would temporarily disappear during column resizing operations
- Root cause identified: `sortAllowed` computed property included `!loading.value` condition
- Solution: Simplified `sortAllowed` to only check for sort field existence and readonly state

## Changes
- **Fix**: Remove loading state dependency from `sortAllowed` computed property
- **Chore**: Bump version to 0.2.10 for bugfix release  
- **Docs**: Update CHANGELOG with technical details

## Test Plan
- [x] Manual sort column remains visible during column resizing
- [x] Manual sort functionality still works correctly
- [x] Quality checks pass (`pnpm run quality`)
- [x] Extension builds successfully

## Technical Details
The issue occurred because the `sortAllowed` computed property included `!loading.value` as a condition. During column resizing operations, the `loading` state could briefly become `true`, causing `sortAllowed` to return `false` and hiding the manual sort column temporarily.

The fix simplifies the logic to:
```javascript
const sortAllowed = computed(() => {
  return !!sortFieldName.value && !readonly.value;
});
```

Closes #27