### PR TITLE
Fix: Replace hardcoded 'id' with dynamic primary key field detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the Super Layout Table Extension will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.15] - 2025-10-27
+
+### Fixed
+- Fixed hardcoded 'id' primary key field assumption throughout the extension (Issue #36)
+- Extension now dynamically detects the actual primary key field from collection schema using `useCollection()` composable
+- All components and utilities now support collections with custom primary key fields (e.g., `uuid`, `custom_id`, etc.)
+
+### Changed
+- **UI Components**: Updated `super-table.vue`, `EditableCellRelational.vue`, `RelationalCell.vue`, and `actions.vue` to use dynamic primary key detection
+- **Utility Functions**: Enhanced `adjustFieldsForDisplays.ts` with `getPrimaryKeyForCollection()` helper
+- All primary key references now use fallback logic: detect from schema → fallback to 'id' with warning
+- Improved compatibility with non-standard Directus installations and custom collection schemas
+
 ## [0.2.14] - 2025-10-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-super-table",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "A powerful and feature-rich table layout extension for Directus 11+ with inline editing, quick filters, and manual sorting",
   "keywords": [
     "directus",

--- a/src/actions.vue
+++ b/src/actions.vue
@@ -94,7 +94,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { useStores } from '@directus/extensions-sdk';
+import { useStores, useCollection } from '@directus/extensions-sdk';
 import { useI18n } from 'vue-i18n';
 import { useTableApi } from './composables/api';
 
@@ -342,15 +342,28 @@ async function duplicateSelectedItems() {
     return;
   }
 
-  // Default to 'id' if primaryKeyField is not provided
-  const primaryKey = props.primaryKeyField || 'id';
+  // Use provided primaryKeyField or fetch from collection schema
+  let pkField = props.primaryKeyField;
+
+  // If not provided, try to get it from the collection using useCollection
+  if (!pkField) {
+    const { primaryKeyField: collectionPK } = useCollection(props.collection);
+    pkField = collectionPK?.value?.field;
+
+    if (!pkField) {
+      console.warn(
+        `[Super Layout Table] Could not determine primary key field for collection "${props.collection}". Using fallback "id" which may cause issues.`
+      );
+      pkField = 'id';
+    }
+  }
 
   for (const itemId of props.selection) {
     // Use tableApi to duplicate with translations
     await tableApi.duplicateItemWithTranslations(
       props.collection,
       itemId,
-      primaryKey,
+      pkField,
       true // include translations
     );
   }

--- a/src/components/CellRenderers/RelationalCell.vue
+++ b/src/components/CellRenderers/RelationalCell.vue
@@ -33,6 +33,7 @@ const props = defineProps<{
   field?: string;
   item?: any;
   options?: Record<string, any>;
+  primaryKeyFieldName?: string;
 }>();
 
 const isMultiple = computed(() => Array.isArray(props.value));
@@ -66,8 +67,8 @@ function formatItem(item: any): string {
 
   // If it's an object, try to find a display field
   if (typeof item === 'object') {
-    // Common display fields in order of preference
-    const displayFields = ['name', 'title', 'label', 'first_name', 'email', 'id'];
+    // Common display fields in order of preference (without hard-coded 'id')
+    const displayFields = ['name', 'title', 'label', 'first_name', 'email'];
 
     for (const field of displayFields) {
       if (item[field] != null) {
@@ -80,16 +81,32 @@ function formatItem(item: any): string {
       return `${item.first_name} ${item.last_name}`;
     }
 
-    // Fallback to id if available
-    return item.id ? String(item.id) : 'Unknown';
+    // Try the primary key field from props
+    if (props.primaryKeyFieldName && item[props.primaryKeyFieldName] != null) {
+      return String(item[props.primaryKeyFieldName]);
+    }
+
+    // Last fallback: try 'id' field
+    if (item.id != null) {
+      return String(item.id);
+    }
+
+    return 'Unknown';
   }
 
   return String(item);
 }
 
 function getItemKey(item: any, index: number): string {
-  if (typeof item === 'object' && item?.id) {
-    return String(item.id);
+  if (typeof item === 'object') {
+    // Try primary key field from props first
+    if (props.primaryKeyFieldName && item[props.primaryKeyFieldName] != null) {
+      return String(item[props.primaryKeyFieldName]);
+    }
+    // Fallback to 'id' field
+    if (item.id != null) {
+      return String(item.id);
+    }
   }
   return `item-${index}`;
 }

--- a/src/components/EditableCellRelational.vue
+++ b/src/components/EditableCellRelational.vue
@@ -4,7 +4,7 @@
     v-if="!isRelational && shouldUseBooleanToggle"
     :model-value="displayValue"
     :collection="item?.collection || field?.collection"
-    :primary-key="(item?.id || item?.[primaryKeyField]) ?? ''"
+    :primary-key="(item?.[primaryKeyField] || item?.id) ?? ''"
     :field="actualFieldKey"
     :disabled="!isFieldEditableComputed"
     :readonly="!props.editMode"
@@ -25,7 +25,7 @@
     :auto-save="false"
     :saving="saving"
     :collection="item?.collection || field?.collection"
-    :primary-key-value="(item?.id || item?.[primaryKeyField]) ?? undefined"
+    :primary-key-value="(item?.[primaryKeyField] || item?.id) ?? undefined"
     :all-translations="item?.translations"
     :style="{ textAlign: props.align || 'left' }"
     :field-support-level="fieldSupportLevel"
@@ -91,6 +91,7 @@
         :value="value"
         :field="actualFieldKey"
         :item="item"
+        :primary-key-field-name="primaryKeyField"
       />
       <!-- FINAL FALLBACK: Raw value display for fields without any special handling -->
       <span v-else class="raw-value">
@@ -139,6 +140,7 @@ const props = defineProps<{
   editMode?: boolean;
   align?: 'left' | 'center' | 'right';
   directBooleanToggle?: boolean;
+  primaryKeyFieldName?: string;
 }>();
 
 const emit = defineEmits<{
@@ -165,7 +167,23 @@ onBeforeMount(() => {
 
 // Computed
 const primaryKeyField = computed(() => {
-  return Object.keys(props.item).find((key) => key === 'id' || key.endsWith('_id')) || 'id';
+  // Use the provided primaryKeyFieldName prop if available
+  if (props.primaryKeyFieldName) {
+    return props.primaryKeyFieldName;
+  }
+
+  // Fallback: Try to detect from item keys
+  const detectedKey = Object.keys(props.item).find((key) => key === 'id' || key.endsWith('_id'));
+  if (detectedKey) {
+    return detectedKey;
+  }
+
+  // Last resort fallback with warning
+  console.warn(
+    '[Super Layout Table] Could not determine primary key field for item. Using fallback "id".',
+    props.item
+  );
+  return 'id';
 });
 
 // Extract language code if present in field key

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -209,6 +209,7 @@
           :edit-mode="editMode"
           :align="header.align"
           :direct-boolean-toggle="(layoutOptions as any)?.directBooleanToggle"
+          :primary-key-field-name="getPrimaryKeyFieldName()"
           @update="updateFieldValue"
           @save="autoSaveEdits"
         />
@@ -343,6 +344,11 @@ const getPrimaryKeyFieldName = () => {
   if ((primaryKeyField as any)?.field) {
     return (primaryKeyField as any).field;
   }
+
+  // Log warning if we couldn't determine the primary key from schema
+  console.warn(
+    `[Super Layout Table] Could not determine primary key field for collection "${collection.value}". Using fallback "id". This may cause issues if your collection uses a different primary key.`
+  );
   return 'id';
 };
 

--- a/src/utils/adjustFieldsForDisplays.ts
+++ b/src/utils/adjustFieldsForDisplays.ts
@@ -1,5 +1,5 @@
 // CORE CHANGES - Following original Directus approach
-import { useStores } from '@directus/extensions-sdk';
+import { useStores, useCollection } from '@directus/extensions-sdk';
 
 /**
  * Helper function to get the related collection for a field
@@ -39,6 +39,28 @@ function isNativeDirectusCollection(collectionName: string | null): boolean {
 }
 
 /**
+ * Get the primary key field name for a collection
+ * Falls back to 'id' if collection is not found or primary key cannot be determined
+ */
+function getPrimaryKeyForCollection(collectionName: string | null): string {
+  if (!collectionName) {
+    return 'id';
+  }
+
+  try {
+    const { primaryKeyField } = useCollection(collectionName);
+    if (primaryKeyField?.value?.field) {
+      return primaryKeyField.value.field;
+    }
+  } catch {
+    // useCollection failed, use fallback
+  }
+
+  // Fallback to 'id' for unknown collections
+  return 'id';
+}
+
+/**
  * Get display fields for file-based displays (image, file)
  * Validates title field existence in directus_files before adding
  */
@@ -47,7 +69,9 @@ function getFileDisplayFields(
   additionalFields: string[],
   fieldsStore: any
 ): string[] {
-  const baseFields = ['id', 'type'];
+  // directus_files always uses 'id' as primary key (system collection)
+  const pkField = getPrimaryKeyForCollection('directus_files');
+  const baseFields = [pkField, 'type'];
   const titleField = fieldExists('directus_files', 'title', fieldsStore) ? ['title'] : [];
   const allFields = [...baseFields, ...titleField, ...additionalFields];
   return allFields.map((f) => `${fieldKey}.${f}`);
@@ -79,19 +103,22 @@ function getDisplayFieldsForRelation(
     return null; // Can't determine collection - return field as-is
   }
 
+  // Get the primary key field for the related collection
+  const pkField = getPrimaryKeyForCollection(relatedCollection);
+
   // Native Directus collections: Try standard fields with validation
   if (isNativeDirectusCollection(relatedCollection)) {
-    const standardFields = ['id', 'status', 'title', 'name'];
+    const standardFields = [pkField, 'status', 'title', 'name'];
     const existingFields = standardFields
       .filter((f) => fieldExists(relatedCollection, f, fieldsStore))
       .map((f) => `${fieldKey}.${f}`);
 
-    // Fallback to id if no standard fields exist
-    return existingFields.length > 0 ? existingFields : [`${fieldKey}.id`];
+    // Fallback to primary key if no standard fields exist
+    return existingFields.length > 0 ? existingFields : [`${fieldKey}.${pkField}`];
   }
 
-  // Custom collections: Conservative approach - only request id
-  return [`${fieldKey}.id`];
+  // Custom collections: Conservative approach - only request primary key
+  return [`${fieldKey}.${pkField}`];
 }
 
 /**
@@ -143,7 +170,15 @@ export function adjustFieldsForDisplays(
               displayFields = templateFields.map((f) => `${fieldKey}.${f}`);
             } else {
               // Default fields for related-values without template
-              displayFields = [`${fieldKey}.id`];
+              // Get the primary key of the related collection
+              const fieldName = fieldKey.split('.')[0];
+              const relatedCollection = getRelatedCollection(
+                parentCollection,
+                fieldName,
+                relationsStore
+              );
+              const pkField = getPrimaryKeyForCollection(relatedCollection);
+              displayFields = [`${fieldKey}.${pkField}`];
             }
             break;
           }
@@ -168,8 +203,9 @@ export function adjustFieldsForDisplays(
           case 'user': {
             // User display needs these specific fields
             // directus_users has standard schema, but validate avatar field
+            const userPkField = getPrimaryKeyForCollection('directus_users');
             displayFields = [
-              `${fieldKey}.id`,
+              `${fieldKey}.${userPkField}`,
               `${fieldKey}.email`,
               `${fieldKey}.first_name`,
               `${fieldKey}.last_name`,
@@ -177,7 +213,9 @@ export function adjustFieldsForDisplays(
 
             // Only add avatar if it exists
             if (fieldExists('directus_users', 'avatar', fieldsStore)) {
-              displayFields.push(`${fieldKey}.avatar.id`);
+              // Avatar references directus_files
+              const avatarPkField = getPrimaryKeyForCollection('directus_files');
+              displayFields.push(`${fieldKey}.avatar.${avatarPkField}`);
             }
             break;
           }


### PR DESCRIPTION
## Summary

This PR fixes Issue #36 by replacing all hardcoded `id` references with dynamic primary key field detection based on the actual collection schema.

## Changes

### Commit 1: UI Components (`e1366b0`)
- **super-table.vue**: Add `getPrimaryKeyFieldName()` using `useCollection()` to detect actual primary key
- **EditableCellRelational.vue**: Accept `primaryKeyFieldName` prop and use it with fallback logic
- **RelationalCell.vue**: Use `primaryKeyFieldName` prop for item display and key generation
- **actions.vue**: Use `useCollection()` in `duplicateSelectedItems()` to get correct primary key

### Commit 2: Utility Function (`9742de8`)
- **adjustFieldsForDisplays.ts**: 
  - Add `getPrimaryKeyForCollection()` helper using `useCollection()` composable
  - Update `getFileDisplayFields()` to use dynamic primary key for `directus_files`
  - Update `getDisplayFieldsForRelation()` to detect primary key per related collection
  - Update `related-values` display case to use dynamic primary key
  - Update `user` display case to use dynamic primary keys for user and avatar fields

## Testing

- ✅ TypeScript type-check passed
- ✅ ESLint lint check passed
- ✅ Build successful

## Breaking Changes

None. The changes are backward compatible and use `id` as fallback when primary key cannot be determined.

## Related Issue

Relates to #36

---

**Note**: This PR implements the code changes. Further testing with collections that use non-standard primary keys is recommended before closing the issue.