### PR TITLE
feat: tag editor support with inline editing (Issue #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated supportedFields.ts: 'tags' interface now fully supported (was 'partial')
 - Enhanced InlineEditPopover.vue with dedicated tag editing interface
 - Improved field support detection for tag fields regardless of JSON type
-- Tag fields now display with proper edit icons instead of lock icons
+- Removed edit pencil icon from editable cells (hover background is sufficient indicator)
+- Edit-icon for non-editable fields (lock) now uses overlay positioning to save cell space
+- Tag chips in editor now show pointer cursor and translated "Remove" tooltip on hover
 
 ### Fixed
 - Tag fields are now properly recognized as editable in table view
 - Resolved field support level detection for tag interface with JSON type
 - Tag fields no longer show "limited support" warnings
-- Fixed edit icon display for tag fields (removed incorrect lock icon)
+- Fixed tag chips being clipped in narrow columns due to edit icon taking inline space
 
 ### Technical Details
 - New component: `src/components/TagCell.vue` (display-only component)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Super Layout Table Extension will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.15] - TBD
+## [0.2.15] - 2025-10-09
 
 ### Added
 - Full support for Tag fields with visual tag editor (Issue #10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to the Super Layout Table Extension will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.14] - 2025-09-15
+
+### Added
+- Full support for Tag fields with visual tag editor (Issue #10)
+- TagCell component for visual tag display as chips in table cells
+- TagEditor component with popover-based editing interface
+- Native Directus v-chip integration for tag display and editing
+- Tag detection for both explicit 'tags' interface and JSON array fields
+- Enhanced field support system for tag fields
+- Popover-based tag editing with Add/Remove functionality
+
+### Changed
+- Updated supportedFields.ts: 'tags' interface now fully supported (was 'partial')
+- Enhanced InlineEditPopover.vue with dedicated tag editing interface
+- Improved field support detection for tag fields regardless of JSON type
+- Tag fields now display with proper edit icons instead of lock icons
+
+### Fixed
+- Tag fields are now properly recognized as editable in table view
+- Resolved field support level detection for tag interface with JSON type
+- Tag fields no longer show "limited support" warnings
+- Fixed edit icon display for tag fields (removed incorrect lock icon)
+
+### Technical Details
+- New component: `src/components/TagCell.vue` (display-only component)
+- New component: `src/components/CellRenderers/TagEditor.vue` (popover editor)
+- Enhanced: `src/components/InlineEditPopover.vue` with tag interface support
+- Updated: `src/components/EditableCellRelational.vue` with tag field integration
+- Modified: `src/utils/fieldSupport.ts` with special case handling for tag fields
+- Updated: `src/constants/supportedFields.ts` with full tag interface support
+
 ## [0.2.13] - 2025-09-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Duplicate items with all their relationships and translations. Perfect for creat
 - **Custom Cell Rendering** - Specialized display for different field types
 - **Relationship Support** - Handle M2O, O2M, M2M, M2A relationships with deep data access
 - **Image Preview** - Inline image display with lightbox support and file browser
+- **Tag Support** - Automatic detection and display of tag fields as visual chips with inline popover editor for adding/removing tags
 - **Status Indicators** - Visual representation of boolean and select fields
 - **Translation Support** - Display multiple language translations as separate columns
 - **Column Alignment** - Configurable text alignment per column (left, center, right)

--- a/src/components/CellRenderers/RelationalCell.vue
+++ b/src/components/CellRenderers/RelationalCell.vue
@@ -97,7 +97,7 @@ function formatItem(item: any): string {
   return String(item);
 }
 
-function getItemKey(item: any, index: number): string {
+function getItemKey(item: any, index: string | number): string {
   if (typeof item === 'object') {
     // Try primary key field from props first
     if (props.primaryKeyFieldName && item[props.primaryKeyFieldName] != null) {

--- a/src/components/CellRenderers/TagEditor.vue
+++ b/src/components/CellRenderers/TagEditor.vue
@@ -1,36 +1,31 @@
 <template>
   <div class="tag-editor">
-    <!-- Current tags display -->
-    <div v-if="localTags.length > 0" class="existing-tags">
-      <v-chip
-        v-for="(tag, index) in localTags"
-        :key="`edit-${tag}-${index}`"
-        close
-        small
-        @close="removeTag(index)"
-        style="
-          --v-chip-background-color: var(--theme--primary-subdued);
-          --v-chip-color: var(--theme--primary);
-          margin-right: 4px;
-          margin-bottom: 4px;
-        "
-      >
-        {{ tag }}
-      </v-chip>
-    </div>
-
-    <!-- Add new tag input -->
+    <!-- Add new tag input OBEN -->
     <div class="tag-input-container">
       <v-input
         v-model="newTag"
         placeholder="Type tag and press Enter..."
         autofocus
+        small
         @keydown.enter.prevent="addTag"
         @keydown.escape="$emit('cancel')"
       />
       <v-button v-if="newTag.trim()" @click="addTag" icon secondary small style="margin-left: 8px">
         <v-icon name="add" />
       </v-button>
+    </div>
+
+    <!-- Current tags display UNTEN -->
+    <div v-if="localTags.length > 0" class="existing-tags">
+      <v-chip
+        v-for="(tag, index) in localTags"
+        :key="`${tag}-${index}`"
+        x-small
+        class="tag-chip-native"
+        @click="removeTag(index)"
+      >
+        {{ tag }}
+      </v-chip>
     </div>
 
     <!-- Tag suggestions (if available) -->
@@ -61,11 +56,6 @@
       <span class="empty-text">No tags yet. Type above to add your first tag.</span>
     </div>
 
-    <!-- Action buttons -->
-    <div class="tag-actions">
-      <v-button @click="$emit('cancel')" secondary small> Cancel </v-button>
-      <v-button @click="saveChanges" :disabled="!hasChanges" small> Save Tags </v-button>
-    </div>
   </div>
 </template>
 
@@ -231,12 +221,15 @@ function saveChanges() {
   font-style: italic;
 }
 
-.tag-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  padding-top: 12px;
-  border-top: 1px solid var(--theme--border-color-subdued);
+/* CLEAN: Nur das Nötigste für native Tags */
+.tag-editor .v-chip {
+  --v-chip-color: white;
+  --v-chip-background-color: var(--theme--primary);
+  margin: 2px;
+}
+
+.tag-editor .v-chip:hover {
+  --v-chip-background-color: var(--theme--danger);
 }
 
 /* Responsive adjustments */
@@ -244,14 +237,6 @@ function saveChanges() {
   .tag-editor {
     min-width: 280px;
     max-width: 320px;
-  }
-
-  .tag-actions {
-    flex-direction: column;
-  }
-
-  .tag-actions > * {
-    width: 100%;
   }
 }
 </style>

--- a/src/components/CellRenderers/TagEditor.vue
+++ b/src/components/CellRenderers/TagEditor.vue
@@ -55,7 +55,6 @@
     <div v-if="localTags.length === 0" class="empty-state">
       <span class="empty-text">No tags yet. Type above to add your first tag.</span>
     </div>
-
   </div>
 </template>
 
@@ -81,7 +80,6 @@ const emit = defineEmits<Emits>();
 
 // State
 const localTags = ref<string[]>([]);
-const originalTags = ref<string[]>([]);
 const newTag = ref('');
 
 // Initialize local tags from props
@@ -90,17 +88,11 @@ watch(
   (newValue) => {
     const parsedTags = parseTagsValue(newValue);
     localTags.value = [...parsedTags];
-    originalTags.value = [...parsedTags];
   },
   { immediate: true }
 );
 
 // Computed
-const hasChanges = computed(() => {
-  if (localTags.value.length !== originalTags.value.length) return true;
-  return !localTags.value.every((tag, index) => tag === originalTags.value[index]);
-});
-
 const suggestions = computed(() => {
   if (!props.suggestions || props.suggestions.length === 0) return [];
 
@@ -154,15 +146,6 @@ function addSuggestion(suggestion: string) {
 function removeTag(index: number) {
   localTags.value.splice(index, 1);
   emit('update:value', localTags.value);
-}
-
-function saveChanges() {
-  // Add current input as tag if it exists
-  if (newTag.value.trim()) {
-    addTag();
-  }
-
-  emit('save', localTags.value);
 }
 </script>
 

--- a/src/components/CellRenderers/TagEditor.vue
+++ b/src/components/CellRenderers/TagEditor.vue
@@ -20,8 +20,9 @@
       <v-chip
         v-for="(tag, index) in localTags"
         :key="`${tag}-${index}`"
+        v-tooltip="t('remove')"
         x-small
-        class="tag-chip-native"
+        class="tag-chip-native tag-removable"
         @click="removeTag(index)"
       >
         {{ tag }}
@@ -60,6 +61,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 interface Props {
   value: string[] | string | null;
@@ -77,6 +79,8 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<Emits>();
+
+const { t } = useI18n();
 
 // State
 const localTags = ref<string[]>([]);
@@ -209,6 +213,10 @@ function removeTag(index: number) {
   --v-chip-color: white;
   --v-chip-background-color: var(--theme--primary);
   margin: 2px;
+}
+
+.tag-removable {
+  cursor: pointer;
 }
 
 .tag-editor .v-chip:hover {

--- a/src/components/CellRenderers/TagEditor.vue
+++ b/src/components/CellRenderers/TagEditor.vue
@@ -1,0 +1,257 @@
+<template>
+  <div class="tag-editor">
+    <!-- Current tags display -->
+    <div v-if="localTags.length > 0" class="existing-tags">
+      <v-chip
+        v-for="(tag, index) in localTags"
+        :key="`edit-${tag}-${index}`"
+        close
+        small
+        @close="removeTag(index)"
+        style="
+          --v-chip-background-color: var(--theme--primary-subdued);
+          --v-chip-color: var(--theme--primary);
+          margin-right: 4px;
+          margin-bottom: 4px;
+        "
+      >
+        {{ tag }}
+      </v-chip>
+    </div>
+
+    <!-- Add new tag input -->
+    <div class="tag-input-container">
+      <v-input
+        v-model="newTag"
+        placeholder="Type tag and press Enter..."
+        autofocus
+        @keydown.enter.prevent="addTag"
+        @keydown.escape="$emit('cancel')"
+      />
+      <v-button v-if="newTag.trim()" @click="addTag" icon secondary small style="margin-left: 8px">
+        <v-icon name="add" />
+      </v-button>
+    </div>
+
+    <!-- Tag suggestions (if available) -->
+    <div v-if="suggestions.length > 0" class="tag-suggestions">
+      <div class="suggestions-label">Suggestions:</div>
+      <div class="suggestions-list">
+        <v-chip
+          v-for="suggestion in suggestions"
+          :key="`suggestion-${suggestion}`"
+          small
+          clickable
+          @click="addSuggestion(suggestion)"
+          style="
+            --v-chip-background-color: var(--theme--background-subdued);
+            --v-chip-color: var(--theme--foreground);
+            margin-right: 4px;
+            margin-bottom: 4px;
+            cursor: pointer;
+          "
+        >
+          {{ suggestion }}
+        </v-chip>
+      </div>
+    </div>
+
+    <!-- Empty state -->
+    <div v-if="localTags.length === 0" class="empty-state">
+      <span class="empty-text">No tags yet. Type above to add your first tag.</span>
+    </div>
+
+    <!-- Action buttons -->
+    <div class="tag-actions">
+      <v-button @click="$emit('cancel')" secondary small> Cancel </v-button>
+      <v-button @click="saveChanges" :disabled="!hasChanges" small> Save Tags </v-button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+
+interface Props {
+  value: string[] | string | null;
+  suggestions?: string[];
+}
+
+interface Emits {
+  (e: 'update:value', value: string[]): void;
+  (e: 'save', value: string[]): void;
+  (e: 'cancel'): void;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  suggestions: () => [],
+});
+
+const emit = defineEmits<Emits>();
+
+// State
+const localTags = ref<string[]>([]);
+const originalTags = ref<string[]>([]);
+const newTag = ref('');
+
+// Initialize local tags from props
+watch(
+  () => props.value,
+  (newValue) => {
+    const parsedTags = parseTagsValue(newValue);
+    localTags.value = [...parsedTags];
+    originalTags.value = [...parsedTags];
+  },
+  { immediate: true }
+);
+
+// Computed
+const hasChanges = computed(() => {
+  if (localTags.value.length !== originalTags.value.length) return true;
+  return !localTags.value.every((tag, index) => tag === originalTags.value[index]);
+});
+
+const suggestions = computed(() => {
+  if (!props.suggestions || props.suggestions.length === 0) return [];
+
+  // Filter out already added tags and current input
+  return props.suggestions.filter(
+    (suggestion) =>
+      !localTags.value.some((tag) => tag.toLowerCase() === suggestion.toLowerCase()) &&
+      suggestion.toLowerCase() !== newTag.value.toLowerCase()
+  );
+});
+
+// Methods
+function parseTagsValue(value: string[] | string | null): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return value.trim() ? [value] : [];
+    }
+  }
+
+  return [];
+}
+
+function addTag() {
+  const trimmed = newTag.value.trim();
+  if (!trimmed) return;
+
+  // Check for duplicates (case insensitive)
+  const exists = localTags.value.some((tag) => tag.toLowerCase() === trimmed.toLowerCase());
+
+  if (!exists) {
+    localTags.value.push(trimmed);
+    emit('update:value', localTags.value);
+  }
+
+  newTag.value = '';
+}
+
+function addSuggestion(suggestion: string) {
+  if (!localTags.value.some((tag) => tag.toLowerCase() === suggestion.toLowerCase())) {
+    localTags.value.push(suggestion);
+    emit('update:value', localTags.value);
+  }
+}
+
+function removeTag(index: number) {
+  localTags.value.splice(index, 1);
+  emit('update:value', localTags.value);
+}
+
+function saveChanges() {
+  // Add current input as tag if it exists
+  if (newTag.value.trim()) {
+    addTag();
+  }
+
+  emit('save', localTags.value);
+}
+</script>
+
+<style scoped>
+.tag-editor {
+  padding: 16px;
+  min-width: 300px;
+  max-width: 400px;
+  background: var(--theme--background);
+  border-radius: 8px;
+}
+
+.existing-tags {
+  margin-bottom: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.tag-input-container {
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.tag-input-container :deep(.v-input) {
+  flex: 1;
+}
+
+.tag-suggestions {
+  margin-bottom: 12px;
+}
+
+.suggestions-label {
+  font-size: 0.875rem;
+  color: var(--theme--foreground-subdued);
+  margin-bottom: 6px;
+  font-weight: 500;
+}
+
+.suggestions-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 20px 0;
+  margin-bottom: 12px;
+}
+
+.empty-text {
+  font-size: 0.875rem;
+  color: var(--theme--foreground-subdued);
+  font-style: italic;
+}
+
+.tag-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--theme--border-color-subdued);
+}
+
+/* Responsive adjustments */
+@media (max-width: 480px) {
+  .tag-editor {
+    min-width: 280px;
+    max-width: 320px;
+  }
+
+  .tag-actions {
+    flex-direction: column;
+  }
+
+  .tag-actions > * {
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/EditableCellRelational.vue
+++ b/src/components/EditableCellRelational.vue
@@ -1,7 +1,41 @@
 <template>
+  <!-- Use InlineEditPopover with TagCell for tag fields -->
+  <InlineEditPopover
+    v-if="!isRelational && shouldUseTagCell"
+    :value="displayValue"
+    :field-key="actualFieldKey"
+    :field-label="field?.name || actualFieldKey"
+    :field-type="field?.type"
+    :interface-type="'tags'"
+    :interface-options="interfaceOptions"
+    :is-editable="isFieldEditableComputed"
+    :is-relational="false"
+    :auto-save="false"
+    :saving="saving"
+    :collection="item?.collection || field?.collection"
+    :primary-key-value="(item?.id || item?.[primaryKeyField]) ?? undefined"
+    :style="{ textAlign: props.align || 'left' }"
+    :field-support-level="fieldSupportLevel"
+    :edit-mode-active="props.editMode"
+    :field-edit-warning="fieldEditWarning"
+    @update:value="handleUpdate"
+    @save="handleSave"
+    @next-field="navigateToNextCell"
+    @prev-field="navigateToPrevCell"
+  >
+    <template #display="{ value }">
+      <TagCell
+        :value="value"
+        :item="item"
+        :field="actualFieldKey"
+        :edit-mode="props.editMode"
+        :alignment="props.align"
+      />
+    </template>
+  </InlineEditPopover>
   <!-- Use BooleanToggleCell for boolean fields when directBooleanToggle is enabled -->
   <BooleanToggleCell
-    v-if="!isRelational && shouldUseBooleanToggle"
+    v-else-if="!isRelational && shouldUseBooleanToggle"
     :model-value="displayValue"
     :collection="item?.collection || field?.collection"
     :primary-key="(item?.id || item?.[primaryKeyField]) ?? ''"
@@ -126,6 +160,7 @@ import SelectCell from './CellRenderers/SelectCell.vue';
 import ImageCell from './CellRenderers/ImageCell.vue';
 import RelationalCell from './CellRenderers/RelationalCell.vue';
 import ColorCell from './CellRenderers/ColorCell.vue';
+import TagCell from './TagCell.vue';
 import { isFieldEditable, getFieldEditWarning, getFieldSupportLevel } from '../utils/fieldSupport';
 
 const props = defineProps<{
@@ -287,6 +322,55 @@ const fieldEditWarning = computed(() => {
 // Get field support level for UI display
 const fieldSupportLevel = computed(() => {
   return getFieldSupportLevel(props.field, actualFieldKey.value);
+});
+
+// Check if we should use TagCell for tag fields
+const shouldUseTagCell = computed(() => {
+  if (!props.field) return false;
+
+  // Primary check: Field has 'tags' interface
+  const interfaceType = props.field.interface || props.field.meta?.interface;
+  if (interfaceType === 'tags') {
+    return true; // Always use TagCell for explicit tag fields
+  }
+
+  // Secondary check: JSON field with string array content (legacy support)
+  if (props.field.type === 'json' && props.editMode) {
+    const value = displayValue.value;
+
+    // Check if value is a string array (tags)
+    if (Array.isArray(value)) {
+      // All items must be strings and non-empty
+      return (
+        value.length === 0 ||
+        value.every((item) => typeof item === 'string' && item.trim().length > 0)
+      );
+    }
+
+    // Check if it's a JSON string that parses to a string array
+    if (typeof value === 'string' && value.trim()) {
+      try {
+        const parsed = JSON.parse(value);
+        return (
+          Array.isArray(parsed) &&
+          (parsed.length === 0 ||
+            parsed.every((item) => typeof item === 'string' && item.trim().length > 0))
+        );
+      } catch {
+        return false;
+      }
+    }
+
+    // Empty/null values in JSON fields could be tags if field name suggests it
+    if ((value === null || value === undefined || value === '') && actualFieldKey.value) {
+      const fieldName = actualFieldKey.value.toLowerCase();
+      return (
+        fieldName.includes('tag') || fieldName.includes('label') || fieldName.includes('keyword')
+      );
+    }
+  }
+
+  return false;
 });
 
 // Check if we should use BooleanToggleCell

--- a/src/components/InlineEditPopover.vue
+++ b/src/components/InlineEditPopover.vue
@@ -174,6 +174,17 @@
             </div>
           </div>
 
+          <!-- Tag Editor -->
+          <div v-else-if="interfaceType === 'tags' || interfaceType === 'tag-list'">
+            <TagEditor
+              :value="localValue"
+              :suggestions="getTagSuggestions()"
+              @update:value="handleTagChange"
+              @save="handleTagSave"
+              @cancel="cancelEdit"
+            />
+          </div>
+
           <!-- JSON/Code Editor for JSON fields -->
           <div v-else-if="isJsonField">
             <interface-input-code
@@ -400,6 +411,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue';
 import { useTableApi } from '../composables/api';
+import TagEditor from './CellRenderers/TagEditor.vue';
 // Note: useDrawer might not be available in all versions, we'll use alternative approach
 
 interface Props {
@@ -796,6 +808,26 @@ function handleDateTimeChange(value: any) {
   if (props.autoSave) {
     debouncedSave(value);
   }
+}
+
+function handleTagChange(tags: string[]) {
+  localValue.value = tags;
+  hasUnsavedChanges.value = true;
+
+  if (props.autoSave) {
+    debouncedSave(tags);
+  }
+}
+
+function handleTagSave(tags: string[]) {
+  localValue.value = tags;
+  saveAndClose();
+}
+
+function getTagSuggestions(): string[] {
+  // TODO: Could be enhanced to fetch suggestions from other records
+  // For now, return empty array
+  return [];
 }
 
 function handleJsonInput(value: string) {

--- a/src/components/InlineEditPopover.vue
+++ b/src/components/InlineEditPopover.vue
@@ -41,17 +41,11 @@
             </template>
           </div>
 
-          <!-- Edit Indicator Icon - show lock or edit icon, but only in edit mode -->
+          <!-- Lock icon for non-editable fields in edit mode -->
           <v-icon
             v-if="!active && !saving && shouldShowIcon()"
             :name="getFieldIcon()"
-            class="edit-icon"
-            :class="{
-              'lock-icon':
-                fieldSupportLevel === 'none' ||
-                fieldSupportLevel === 'readonly' ||
-                fieldSupportLevel === 'partial',
-            }"
+            class="lock-icon"
             x-small
           />
         </div>
@@ -654,27 +648,20 @@ function getFieldTooltip() {
 }
 
 function shouldShowIcon() {
-  // Only show icons when edit mode is active globally
+  // Only show lock icons when edit mode is active and field is not editable
   if (!props.editModeActive) {
     return false;
   }
-
-  // In edit mode, show appropriate icons
-  return true;
+  // Only show icon for non-editable fields (lock indicator)
+  return (
+    props.fieldSupportLevel === 'none' ||
+    props.fieldSupportLevel === 'readonly' ||
+    props.fieldSupportLevel === 'partial'
+  );
 }
 
 function getFieldIcon() {
-  if (
-    props.fieldSupportLevel === 'partial' ||
-    props.fieldSupportLevel === 'none' ||
-    props.fieldSupportLevel === 'readonly'
-  ) {
-    return 'lock'; // Lock for all non-editable fields
-  }
-  if (props.isEditable && !props.isRelational) {
-    return 'edit'; // Edit pencil for fully supported
-  }
-  return 'lock'; // Default to lock
+  return 'lock';
 }
 
 function handleCellClick(toggle: Function) {
@@ -1151,7 +1138,6 @@ onUnmounted(() => {
   height: 100%;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   cursor: default;
   transition: all var(--fast) var(--transition);
   border-radius: var(--border-radius);
@@ -1187,23 +1173,19 @@ onUnmounted(() => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 100%;
+  width: 100%;
 }
 
-.edit-icon {
-  opacity: 0;
-  transition: opacity var(--fast) var(--transition);
-  margin-left: 8px;
+.lock-icon {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
   color: var(--foreground-subdued);
-  flex-shrink: 0;
-}
-
-.edit-cell.is-editable:hover .edit-icon {
   opacity: 0.6;
-}
-
-.edit-cell.is-editable:focus .edit-icon {
-  opacity: 1;
+  flex-shrink: 0;
+  z-index: 1;
+  pointer-events: none;
 }
 
 .edit-cell.non-editable {
@@ -1672,12 +1654,6 @@ onUnmounted(() => {
 .edit-cell.field-readonly:hover,
 .edit-cell.field-partial:hover {
   background-color: var(--background-subdued);
-}
-
-/* Lock icon styling */
-.edit-icon.lock-icon {
-  color: var(--foreground-subdued);
-  opacity: 0.6;
 }
 
 /* Override cursor for non-editable cells - NUR im Edit-Mode */

--- a/src/components/TagCell.vue
+++ b/src/components/TagCell.vue
@@ -6,12 +6,7 @@
         v-for="(tag, index) in visibleTags"
         :key="`${tag}-${index}`"
         small
-        style="
-          --v-chip-background-color: var(--theme--primary-subdued);
-          --v-chip-color: var(--theme--primary);
-          margin-right: 4px;
-          margin-bottom: 2px;
-        "
+        class="tag-chip-display"
       >
         {{ tag }}
       </v-chip>
@@ -103,6 +98,14 @@ const additionalCount = computed(() => displayTags.value.length - props.maxVisib
   font-size: 0.875rem;
   color: var(--theme--foreground-subdued);
   font-style: italic;
+}
+
+/* Tag styling for table display */
+.tag-chip-display {
+  --v-chip-background-color: #e5e7eb !important; /* Grauer Hintergrund */
+  --v-chip-color: #1f2937 !important; /* Schwarze/dunkle Schrift */
+  margin-right: 4px;
+  margin-bottom: 2px;
 }
 
 /* Responsive behavior */

--- a/src/components/TagCell.vue
+++ b/src/components/TagCell.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="tag-cell" :class="`align-${alignment || 'left'}`">
+    <!-- Display Mode: Show tags as chips (Display-Only like ColorCell) -->
+    <div class="tag-display">
+      <v-chip
+        v-for="(tag, index) in visibleTags"
+        :key="`${tag}-${index}`"
+        small
+        style="
+          --v-chip-background-color: var(--theme--primary-subdued);
+          --v-chip-color: var(--theme--primary);
+          margin-right: 4px;
+          margin-bottom: 2px;
+        "
+      >
+        {{ tag }}
+      </v-chip>
+      <span v-if="hasMore" class="tag-more">+{{ additionalCount }} more</span>
+      <span v-if="displayTags.length === 0" class="tag-empty">No tags</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+interface Props {
+  value: string[] | string | null;
+  item?: any;
+  field?: string;
+  editMode?: boolean;
+  alignment?: 'left' | 'center' | 'right';
+  maxVisible?: number;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  maxVisible: 3,
+  alignment: 'left',
+});
+
+// Computed
+const displayTags = computed<string[]>(() => {
+  if (!props.value) return [];
+  if (Array.isArray(props.value)) return props.value;
+
+  // Handle JSON string
+  if (typeof props.value === 'string') {
+    try {
+      const parsed = JSON.parse(props.value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      // If it's not JSON, treat as single tag
+      return props.value.trim() ? [props.value] : [];
+    }
+  }
+
+  return [];
+});
+
+const visibleTags = computed(() => displayTags.value.slice(0, props.maxVisible));
+
+const hasMore = computed(() => displayTags.value.length > props.maxVisible);
+
+const additionalCount = computed(() => displayTags.value.length - props.maxVisible);
+</script>
+
+<style scoped>
+.tag-cell {
+  width: 100%;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+}
+
+.tag-cell.align-left {
+  justify-content: flex-start;
+}
+
+.tag-cell.align-center {
+  justify-content: center;
+}
+
+.tag-cell.align-right {
+  justify-content: flex-end;
+}
+
+.tag-display {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  min-height: 28px;
+}
+
+.tag-more {
+  font-size: 0.875rem;
+  color: var(--theme--foreground-subdued);
+  font-style: italic;
+  margin-left: 4px;
+}
+
+.tag-empty {
+  font-size: 0.875rem;
+  color: var(--theme--foreground-subdued);
+  font-style: italic;
+}
+
+/* Responsive behavior */
+@media (max-width: 768px) {
+  .tag-display {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+</style>

--- a/src/components/TagCell.vue
+++ b/src/components/TagCell.vue
@@ -1,10 +1,15 @@
 <template>
-  <div class="tag-cell" :class="`align-${alignment || 'left'}`">
+  <div ref="containerRef" class="tag-cell" :class="`align-${alignment || 'left'}`">
     <!-- Display Mode: Show tags as chips (Display-Only like ColorCell) -->
-    <div class="tag-display">
+    <div ref="displayRef" class="tag-display">
       <v-chip
         v-for="(tag, index) in visibleTags"
         :key="`${tag}-${index}`"
+        :ref="
+          (el: unknown) => {
+            if (el) chipRefs[index] = el as HTMLElement;
+          }
+        "
         small
         class="tag-chip-display"
       >
@@ -17,7 +22,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref, onMounted, onBeforeUpdate, watch, nextTick } from 'vue';
 
 interface Props {
   value: string[] | string | null;
@@ -25,12 +30,21 @@ interface Props {
   field?: string;
   editMode?: boolean;
   alignment?: 'left' | 'center' | 'right';
-  maxVisible?: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  maxVisible: 3,
   alignment: 'left',
+});
+
+// Refs
+const containerRef = ref<HTMLElement | null>(null);
+const displayRef = ref<HTMLElement | null>(null);
+const chipRefs: Record<number, HTMLElement> = {};
+const visibleCount = ref<number>(0);
+
+// Clear chip refs before each update
+onBeforeUpdate(() => {
+  Object.keys(chipRefs).forEach((key) => delete chipRefs[Number(key)]);
 });
 
 // Computed
@@ -52,11 +66,118 @@ const displayTags = computed<string[]>(() => {
   return [];
 });
 
-const visibleTags = computed(() => displayTags.value.slice(0, props.maxVisible));
+const visibleTags = computed(() => {
+  if (visibleCount.value === 0) {
+    return displayTags.value;
+  }
+  return displayTags.value.slice(0, visibleCount.value);
+});
 
-const hasMore = computed(() => displayTags.value.length > props.maxVisible);
+const hasMore = computed(() => {
+  if (visibleCount.value === 0) return false;
+  return displayTags.value.length > visibleCount.value;
+});
 
-const additionalCount = computed(() => displayTags.value.length - props.maxVisible);
+const additionalCount = computed(() => {
+  if (visibleCount.value === 0) return 0;
+  return Math.max(0, displayTags.value.length - visibleCount.value);
+});
+
+// Calculate how many tags fit in available space
+async function calculateVisibleTags() {
+  if (!containerRef.value || !displayRef.value || displayTags.value.length === 0) {
+    visibleCount.value = displayTags.value.length;
+    return;
+  }
+
+  // If chips aren't rendered yet, show all first to get measurements
+  if (Object.keys(chipRefs).length === 0 && visibleCount.value === 0) {
+    visibleCount.value = displayTags.value.length;
+    await nextTick();
+    // Recalculate after chips are rendered
+    if (Object.keys(chipRefs).length > 0) {
+      calculateVisibleTags();
+    }
+    return;
+  }
+
+  const containerWidth = containerRef.value.offsetWidth;
+  const moreTextWidth = 80; // Estimated width for "+X more" text
+  const gap = 4; // Gap between chips
+  const padding = 16; // Container padding
+
+  // Measure all chips
+  const chipWidths: number[] = [];
+  for (let i = 0; i < displayTags.value.length; i++) {
+    const chip = chipRefs[i];
+    if (chip) {
+      chipWidths[i] = chip.offsetWidth;
+    } else {
+      // Estimate if not yet rendered
+      chipWidths[i] = displayTags.value[i].length * 8 + 20;
+    }
+  }
+
+  // Calculate how many fit
+  let totalWidth = padding;
+  let count = 0;
+
+  for (let i = 0; i < displayTags.value.length; i++) {
+    const chipWidth = chipWidths[i];
+    const willHaveMore = i + 1 < displayTags.value.length;
+
+    // Calculate available width (reserve space for "+X more" if there will be more tags)
+    const availableWidth = willHaveMore ? containerWidth - moreTextWidth : containerWidth;
+
+    // Check if adding this chip would exceed available width
+    if (totalWidth + chipWidth + gap > availableWidth) {
+      break;
+    }
+
+    totalWidth += chipWidth + gap;
+    count++;
+  }
+
+  // Show at least 1 tag if there's any space
+  const newCount = Math.max(1, count);
+
+  // Only update if changed to prevent infinite loops
+  if (newCount !== visibleCount.value) {
+    visibleCount.value = newCount;
+  }
+}
+
+// Watch for changes and recalculate
+watch(
+  () => displayTags.value,
+  async () => {
+    await nextTick();
+    calculateVisibleTags();
+  },
+  { immediate: true }
+);
+
+// Setup ResizeObserver to recalculate on column resize
+onMounted(() => {
+  if (!containerRef.value) return;
+
+  // eslint-disable-next-line no-undef
+  const resizeObserver = new ResizeObserver(() => {
+    calculateVisibleTags();
+  });
+
+  resizeObserver.observe(containerRef.value);
+
+  // Initial calculation
+  nextTick(() => {
+    calculateVisibleTags();
+  });
+
+  // Cleanup
+  return () => {
+    resizeObserver.disconnect();
+  };
+});
 </script>
 
 <style scoped>
@@ -81,10 +202,12 @@ const additionalCount = computed(() => displayTags.value.length - props.maxVisib
 
 .tag-display {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
   gap: 4px;
   min-height: 28px;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .tag-more {
@@ -108,11 +231,8 @@ const additionalCount = computed(() => displayTags.value.length - props.maxVisib
   margin-bottom: 2px;
 }
 
-/* Responsive behavior */
-@media (max-width: 768px) {
-  .tag-display {
-    flex-direction: column;
-    align-items: flex-start;
-  }
+/* Individual tag chip styling */
+.tag-chip-display {
+  flex-shrink: 0;
 }
 </style>

--- a/src/constants/supportedFields.ts
+++ b/src/constants/supportedFields.ts
@@ -68,8 +68,8 @@ export const SUPPORTED_INTERFACES: Record<string, boolean | 'partial'> = {
   file: false, // General files (PDFs, docs, etc.) are not supported
   files: false, // Multiple files are not supported
 
-  // Partially supported (with known issues)
-  tags: 'partial', // Issue #10 - needs proper support
+  // Tag interface - FULLY SUPPORTED with TagCell and TagEditor (Issue #10 resolved)
+  tags: true, // Fully supported with TagCell component and TagEditor popover
 
   // Date/Time interfaces - NOW SUPPORTED (Issue #5 fixed)
   datetime: true,

--- a/src/utils/fieldSupport.ts
+++ b/src/utils/fieldSupport.ts
@@ -40,6 +40,12 @@ export function isFieldEditable(field: Field | null, fieldKey?: string): boolean
   // Check interface support FIRST for special cases
   const interfaceType = field.meta?.interface || field.interface;
 
+  // Special case: TAG fields with JSON type are fully supported
+  // Tags interface provides complete editing functionality for JSON arrays
+  if (interfaceType === 'tags') {
+    return true; // Tags are fully supported regardless of underlying JSON type
+  }
+
   // Special case: IMAGE fields with UUID type are fully supported
   // Note: Only image files, not general files!
   if (interfaceType === 'file-image' || interfaceType === 'image') {
@@ -149,8 +155,6 @@ export function getFieldEditWarning(field: Field | null, fieldKey?: string): str
   if (interfaceSupported === 'partial') {
     // Provide specific messages for known partial support cases
     switch (interfaceType) {
-      case 'tags':
-        return 'Tag fields have limited support (Issue #10). Complex tag operations should be done in detail view.';
       case 'files':
         return 'Multiple file fields have limited support. Use the detail view for managing multiple files.';
       default:
@@ -190,6 +194,11 @@ export function getFieldSupportLevel(field: Field | null, fieldKey?: string): Fi
   }
 
   const interfaceType = field.meta?.interface || field.interface;
+
+  // Special case: TAG fields are fully supported (regardless of JSON type)
+  if (interfaceType === 'tags') {
+    return 'full';
+  }
 
   // Special case: IMAGE fields are fully supported (not general files!)
   if (interfaceType === 'file-image' || interfaceType === 'image') {


### PR DESCRIPTION
## Summary
- Full support for Tag fields with visual tag editor and inline popover editing
- Automatic detection of tag fields (Directus `tags` interface + JSON string arrays)
- Tag chips display in table cells with dynamic truncation based on column width
- Removed edit pencil icon from all editable cells (hover background is sufficient)
- Lock icon for non-editable fields now uses overlay positioning, saving ~20px cell space
- Tag chips in editor show pointer cursor and translated "Remove" tooltip

## Test plan
- [x] Open a collection with a tag field and verify tags display as chips
- [x] Click on a tag cell to open the editor popover
- [x] Add and remove tags, verify save works
- [x] Hover over tag chips in editor to see pointer cursor and "Remove" tooltip
- [x] Verify no edit pencil icon appears on hover for editable cells
- [x] Verify lock icon still shows for non-editable fields in edit mode
- [x] Test with narrow columns to verify tags are no longer clipped

Closes #10