### PR TITLE
feat: per-column display configuration for relational fields (#48)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,11 @@ claude.md
 **/.DS_Store
 /release/
 *.tar.gz
+.superpowers/
+.playwright-mcp/
+issue47-*.png
+issue48-*.png
+live-test-*.png
+tags-vs-real-tags.png
+status-cell-debug.png
+current-page.png

--- a/index.ts
+++ b/index.ts
@@ -27,18 +27,20 @@ const layoutConfig = {
     // components (options sidebar). Each entry uses the *root* field key as id
     // (translations.title rather than translations.title:de-DE) so all
     // language variants of the same root field share a single override entry.
+    // Multiple language columns of the same root collapse into one picker entry.
     const availableFieldChoices = computed(() => {
       const layoutFields: string[] = props.layoutQuery?.fields ?? [];
       const customFieldNames: Record<string, string> = props.layoutOptions?.customFieldNames ?? {};
-      return layoutFields.map((key: string) => {
-        // Storage key: strip language suffix so translations roll up to a
-        // single override entry per root field.
+      const seen = new Map<string, { key: string; label: string }>();
+      for (const key of layoutFields) {
         const rootKey = key.includes(':') ? key.split(':')[0] : key;
+        if (seen.has(rootKey)) continue;
         const root = rootKey.split('.')[0];
         const fieldData = fieldsStore.getField(props.collection, root);
         const fallbackName = fieldData?.name ?? formatTitle(rootKey);
-        return { key: rootKey, label: customFieldNames[key] ?? fallbackName };
-      });
+        seen.set(rootKey, { key: rootKey, label: customFieldNames[key] ?? fallbackName });
+      }
+      return Array.from(seen.values());
     });
 
     return {

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,6 @@
-import { defineLayout } from '@directus/extensions-sdk';
+import { computed } from 'vue';
+import { defineLayout, useCollection, useStores } from '@directus/extensions-sdk';
+import { formatTitle } from '@directus/format-title';
 import LayoutComponent from './src/super-table.vue';
 import ActionsComponent from './src/actions.vue';
 import OptionsComponent from './src/options.vue';
@@ -17,9 +19,32 @@ const layoutConfig = {
   },
   headerShadow: false,
   setup(props: any, { emit }: any) {
+    const { useFieldsStore } = useStores();
+    const fieldsStore = useFieldsStore();
+    useCollection(props.collection); // parity with super-table.vue
+
+    // Issue #48: Expose a flat list of currently visible columns to slot
+    // components (options sidebar). Each entry uses the *root* field key as id
+    // (translations.title rather than translations.title:de-DE) so all
+    // language variants of the same root field share a single override entry.
+    const availableFieldChoices = computed(() => {
+      const layoutFields: string[] = props.layoutQuery?.fields ?? [];
+      const customFieldNames: Record<string, string> = props.layoutOptions?.customFieldNames ?? {};
+      return layoutFields.map((key: string) => {
+        // Storage key: strip language suffix so translations roll up to a
+        // single override entry per root field.
+        const rootKey = key.includes(':') ? key.split(':')[0] : key;
+        const root = rootKey.split('.')[0];
+        const fieldData = fieldsStore.getField(props.collection, root);
+        const fallbackName = fieldData?.name ?? formatTitle(rootKey);
+        return { key: rootKey, label: customFieldNames[key] ?? fallbackName };
+      });
+    });
+
     return {
       ...props,
       emit,
+      availableFieldChoices,
     };
   },
 } as any;

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test:watch": "vitest --watch",
     "test:e2e": "node playwright-tools/test-extension.js",
     "test:e2e:issue-47": "node playwright-tools/test-issue-47.js",
+    "test:e2e:issue-48": "node playwright-tools/test-issue-48.js",
     "inspect": "node playwright-tools/inspect-vertical-alignment.js",
     "console": "node playwright-tools/playwright-console-monitor.js",
     "analyze": "node playwright-tools/playwright-assistant.js --report",

--- a/src/components/ColumnDisplayEditor.vue
+++ b/src/components/ColumnDisplayEditor.vue
@@ -104,24 +104,22 @@ watch(
 
 <style scoped>
 .column-display-editor {
-  border: 2px solid var(--primary);
-  border-radius: 4px;
-  padding: 8px;
-  background: var(--background-page);
-  margin-bottom: 4px;
+  width: 100%;
+  margin-bottom: 12px;
 }
 .field {
-  margin-bottom: 8px;
+  margin-bottom: 12px;
 }
 .label {
-  font-size: 10px;
-  text-transform: uppercase;
-  color: var(--foreground-subdued);
+  display: block;
   margin-bottom: 4px;
+  color: var(--foreground-normal);
+  font-weight: 600;
+  font-size: 13px;
 }
 .actions {
   display: flex;
-  gap: 6px;
+  gap: 8px;
   justify-content: flex-end;
 }
 </style>

--- a/src/components/ColumnDisplayEditor.vue
+++ b/src/components/ColumnDisplayEditor.vue
@@ -1,0 +1,127 @@
+<template>
+  <div class="column-display-editor">
+    <div class="field">
+      <div class="label">Field</div>
+      <v-select
+        :model-value="form.fieldKey"
+        :items="availableFieldChoices"
+        :disabled="mode === 'edit'"
+        placeholder="Select a column"
+        @update:model-value="onFieldChange"
+      />
+    </div>
+
+    <div class="field">
+      <div class="label">Display Template</div>
+      <interface-system-display-template
+        :collection-name="targetCollection"
+        :value="form.template"
+        placeholder="{{ field }}"
+        :include-relations="true"
+        @input="form.template = $event ?? ''"
+      />
+    </div>
+
+    <div class="actions">
+      <v-button secondary small @click="$emit('cancel')">Cancel</v-button>
+      <v-button :disabled="!canSave" small @click="onSave">Save</v-button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref, watch } from 'vue';
+import { useStores } from '@directus/extensions-sdk';
+import type { ColumnDisplay } from '../composables/useColumnDisplays';
+import { isRelational, resolveTargetCollection } from '../utils/displayHeuristics';
+
+const props = defineProps<{
+  mode: 'add' | 'edit';
+  initialFieldKey?: string;
+  initialValue?: ColumnDisplay;
+  collection: string;
+  availableFieldChoices: Array<{ text: string; value: string }>;
+}>();
+
+const emit = defineEmits<{
+  (e: 'save', payload: { fieldKey: string; display: ColumnDisplay }): void;
+  (e: 'cancel'): void;
+}>();
+
+const { useFieldsStore, useRelationsStore } = useStores();
+const fieldsStore = useFieldsStore();
+const relationsStore = useRelationsStore();
+
+const form = ref<{ fieldKey: string; template: string }>({
+  fieldKey: props.initialFieldKey ?? '',
+  template: props.initialValue?.template ?? '',
+});
+
+const targetCollection = computed(() => {
+  if (!form.value.fieldKey) return null;
+  // Strip language suffix (translations.title:de-DE → translations.title)
+  const rootKey = form.value.fieldKey.includes(':')
+    ? form.value.fieldKey.split(':')[0]
+    : form.value.fieldKey;
+  // Use root field on the parent for relational lookup
+  const rootField = rootKey.split('.')[0];
+  const fieldDef = fieldsStore.getField(props.collection, rootField);
+  if (!fieldDef) return props.collection;
+  if (!isRelational(fieldDef)) return props.collection;
+  const target = resolveTargetCollection(fieldDef, relationsStore as any, fieldsStore as any);
+  return target ?? props.collection;
+});
+
+const canSave = computed(() => {
+  if (!form.value.fieldKey) return false;
+  // Save is disabled in both modes when the template is empty. To delete an
+  // existing override the user clicks the ⊘ icon on the item, which is the
+  // explicit, discoverable path. (Avoids a "Save erases my override" surprise.)
+  if (!form.value.template.trim()) return false;
+  return true;
+});
+
+function onFieldChange(value: string) {
+  form.value.fieldKey = value;
+  // When the chosen field changes, clear the template to avoid stale tokens
+  form.value.template = '';
+}
+
+function onSave() {
+  emit('save', {
+    fieldKey: form.value.fieldKey,
+    display: { template: form.value.template },
+  });
+}
+
+watch(
+  () => props.initialValue,
+  (val) => {
+    if (val) form.value.template = val.template;
+  }
+);
+</script>
+
+<style scoped>
+.column-display-editor {
+  border: 2px solid var(--primary);
+  border-radius: 4px;
+  padding: 8px;
+  background: var(--background-page);
+  margin-bottom: 4px;
+}
+.field {
+  margin-bottom: 8px;
+}
+.label {
+  font-size: 10px;
+  text-transform: uppercase;
+  color: var(--foreground-subdued);
+  margin-bottom: 4px;
+}
+.actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+</style>

--- a/src/components/ColumnDisplayItem.vue
+++ b/src/components/ColumnDisplayItem.vue
@@ -32,15 +32,17 @@ function onDelete() {
 
 <style scoped>
 .column-display-item {
-  padding: 8px;
-  border: 1px solid var(--primary);
-  background: var(--primary-25);
-  border-radius: 4px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subdued);
+  background: var(--background-subdued);
+  border-radius: var(--border-radius);
   cursor: pointer;
-  margin-bottom: 4px;
+  margin-bottom: 6px;
 }
 .column-display-item:hover {
-  background: var(--primary-50);
+  border-color: var(--border-normal);
+  background: var(--background-normal-alt, var(--background-subdued));
 }
 .header {
   display: flex;
@@ -49,16 +51,18 @@ function onDelete() {
 }
 .field-label {
   font-weight: 600;
-  font-size: 12px;
+  font-size: 13px;
+  color: var(--foreground-normal);
 }
 .actions {
   display: flex;
   gap: 4px;
+  color: var(--foreground-subdued);
 }
 .template-preview {
-  font-family: monospace;
-  font-size: 11px;
-  color: var(--primary);
+  font-family: var(--family-monospace);
+  font-size: 12px;
+  color: var(--foreground-subdued);
   margin-top: 4px;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/ColumnDisplayItem.vue
+++ b/src/components/ColumnDisplayItem.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="column-display-item" @click="$emit('edit')">
+    <div class="header">
+      <span class="field-label">{{ fieldLabel }}</span>
+      <div class="actions" @click.stop>
+        <v-icon name="edit" small clickable @click="$emit('edit')" />
+        <v-icon name="close" small clickable @click="onDelete" />
+      </div>
+    </div>
+    <div class="template-preview">{{ display.template }}</div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { ColumnDisplay } from '../composables/useColumnDisplays';
+
+defineProps<{
+  fieldKey: string;
+  fieldLabel: string;
+  display: ColumnDisplay;
+}>();
+
+const emit = defineEmits<{
+  (e: 'edit'): void;
+  (e: 'delete'): void;
+}>();
+
+function onDelete() {
+  emit('delete');
+}
+</script>
+
+<style scoped>
+.column-display-item {
+  padding: 8px;
+  border: 1px solid var(--primary);
+  background: var(--primary-25);
+  border-radius: 4px;
+  cursor: pointer;
+  margin-bottom: 4px;
+}
+.column-display-item:hover {
+  background: var(--primary-50);
+}
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.field-label {
+  font-weight: 600;
+  font-size: 12px;
+}
+.actions {
+  display: flex;
+  gap: 4px;
+}
+.template-preview {
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--primary);
+  margin-top: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/src/components/ColumnDisplaysSection.vue
+++ b/src/components/ColumnDisplaysSection.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="column-displays-section">
+    <div class="section-label">Column Displays</div>
+
+    <template v-for="(display, fieldKey) in columnDisplays" :key="fieldKey">
+      <ColumnDisplayEditor
+        v-if="editingFieldKey === fieldKey"
+        mode="edit"
+        :initial-field-key="String(fieldKey)"
+        :initial-value="display"
+        :collection="collection"
+        :available-field-choices="choicesIncluding(String(fieldKey))"
+        @save="onSave"
+        @cancel="editingFieldKey = null"
+      />
+      <ColumnDisplayItem
+        v-else
+        :field-key="String(fieldKey)"
+        :field-label="labelFor(String(fieldKey))"
+        :display="display"
+        @edit="editingFieldKey = String(fieldKey)"
+        @delete="onDelete(String(fieldKey))"
+      />
+    </template>
+
+    <ColumnDisplayEditor
+      v-if="editingFieldKey === '__new__'"
+      mode="add"
+      :collection="collection"
+      :available-field-choices="addModeChoices"
+      @save="onSave"
+      @cancel="editingFieldKey = null"
+    />
+
+    <button v-if="editingFieldKey === null" class="add-button" @click="editingFieldKey = '__new__'">
+      <v-icon name="add" small /> Add Column Display
+    </button>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from 'vue';
+import ColumnDisplayItem from './ColumnDisplayItem.vue';
+import ColumnDisplayEditor from './ColumnDisplayEditor.vue';
+import type { ColumnDisplay } from '../composables/useColumnDisplays';
+
+const props = defineProps<{
+  collection: string;
+  columnDisplays: Record<string, ColumnDisplay>;
+  availableFields: Array<{ key: string; label: string }>;
+}>();
+
+const emit = defineEmits<{
+  (e: 'set', payload: { fieldKey: string; display: ColumnDisplay }): void;
+  (e: 'remove', fieldKey: string): void;
+}>();
+
+const editingFieldKey = ref<string | null>(null);
+
+const addModeChoices = computed(() =>
+  props.availableFields
+    .filter((f) => !(f.key in props.columnDisplays))
+    .map((f) => ({ text: f.label, value: f.key }))
+);
+
+function choicesIncluding(key: string) {
+  // In edit mode the field is locked, but still pass the current key as a choice
+  const current = props.availableFields.find((f) => f.key === key);
+  if (!current) return addModeChoices.value;
+  return [{ text: current.label, value: current.key }];
+}
+
+function labelFor(key: string): string {
+  return props.availableFields.find((f) => f.key === key)?.label ?? key;
+}
+
+function onSave(payload: { fieldKey: string; display: ColumnDisplay }) {
+  emit('set', payload);
+  editingFieldKey.value = null;
+}
+
+function onDelete(fieldKey: string) {
+  emit('remove', fieldKey);
+}
+</script>
+
+<style scoped>
+.column-displays-section {
+  margin-top: 16px;
+}
+.section-label {
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  color: var(--foreground-subdued);
+  margin-bottom: 8px;
+}
+.add-button {
+  width: 100%;
+  padding: 8px;
+  border: 2px dashed var(--primary-50);
+  background: transparent;
+  border-radius: 4px;
+  color: var(--primary);
+  font-size: 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+.add-button:hover {
+  background: var(--primary-10);
+}
+</style>

--- a/src/components/ColumnDisplaysSection.vue
+++ b/src/components/ColumnDisplaysSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="column-displays-section">
-    <div class="section-label">Column Displays</div>
+    <div class="type-label">Column Displays</div>
 
     <template v-for="(display, fieldKey) in columnDisplays" :key="fieldKey">
       <ColumnDisplayEditor
@@ -86,30 +86,33 @@ function onDelete(fieldKey: string) {
 
 <style scoped>
 .column-displays-section {
-  margin-top: 16px;
+  /* The Directus layout-options sidebar is a 2-col CSS grid; span both cols */
+  grid-column: 1 / -1;
+  margin-top: var(--form-vertical-gap);
 }
-.section-label {
-  font-weight: 600;
-  font-size: 12px;
-  text-transform: uppercase;
-  color: var(--foreground-subdued);
+.type-label {
+  display: block;
   margin-bottom: 8px;
+  color: var(--foreground-normal);
+  font-weight: 600;
+  font-size: 14px;
 }
 .add-button {
   width: 100%;
   padding: 8px;
-  border: 2px dashed var(--primary-50);
+  border: 1px dashed var(--border-normal);
   background: transparent;
-  border-radius: 4px;
-  color: var(--primary);
-  font-size: 12px;
+  border-radius: var(--border-radius);
+  color: var(--foreground-subdued);
+  font-size: 13px;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: 6px;
 }
 .add-button:hover {
-  background: var(--primary-10);
+  border-color: var(--primary);
+  color: var(--primary);
 }
 </style>

--- a/src/components/EditableCellRelational.vue
+++ b/src/components/EditableCellRelational.vue
@@ -101,12 +101,12 @@
         :field="actualFieldKey"
         :alignment="align"
       />
-      <!-- ABSOLUTE PRIORITY: User-configured display templates (ALL field types) -->
+      <!-- ABSOLUTE PRIORITY: Resolved display via override → field → heuristic chain -->
       <render-display
-        v-if="field?.display"
+        v-if="resolvedDisplay.display !== null"
         :value="value"
-        :display="field?.display"
-        :options="field?.displayOptions"
+        :display="resolvedDisplay.display"
+        :options="resolvedDisplay.options"
         :interface="field?.interface"
         :interface-options="field?.interfaceOptions"
         :type="field?.type"
@@ -137,7 +137,7 @@
 
   <!-- ABSOLUTE PRIORITY: Display templates for relational fields -->
   <div
-    v-else-if="field?.display"
+    v-else-if="resolvedDisplay.display !== null"
     class="editable-cell relational"
     :style="{ textAlign: props.align || 'left' }"
   >
@@ -156,6 +156,7 @@
 <script lang="ts" setup>
 import { computed, onBeforeMount, markRaw, ref } from 'vue';
 import type { Field, Item } from '@directus/types';
+import { useStores } from '@directus/extensions-sdk';
 import InlineEditPopover from './InlineEditPopover.vue';
 import BooleanToggleCell from './CellRenderers/BooleanToggleCell.vue';
 import SelectCell from './CellRenderers/SelectCell.vue';
@@ -164,6 +165,11 @@ import RelationalCell from './CellRenderers/RelationalCell.vue';
 import ColorCell from './CellRenderers/ColorCell.vue';
 import TagCell from './TagCell.vue';
 import { isFieldEditable, getFieldEditWarning, getFieldSupportLevel } from '../utils/fieldSupport';
+import { pickHeuristic } from '../utils/displayHeuristics';
+
+const { useFieldsStore, useRelationsStore } = useStores();
+const fieldsStore = useFieldsStore();
+const relationsStore = useRelationsStore();
 
 const props = defineProps<{
   item: Item;
@@ -178,6 +184,7 @@ const props = defineProps<{
   directBooleanToggle?: boolean;
   primaryKeyFieldName?: string;
   languageCodeField?: string;
+  columnDisplays?: Record<string, { template: string; display?: string }>;
 }>();
 
 const emit = defineEmits<{
@@ -274,16 +281,67 @@ const displayValue = computed(() => {
     return null;
   }
 
-  // Handle relational fields with display templates
-  const template =
+  // Handle relational fields with display templates.
+  // Resolved priority: override → field-display → heuristic → none.
+  // Issue #48: layout-level override (columnDisplays) takes priority over the
+  // field-settings display.
+  const storageKey = props.fieldKey.includes(':') ? props.fieldKey.split(':')[0] : props.fieldKey;
+  const override = props.columnDisplays?.[storageKey];
+  const fieldTemplate =
     props.field?.displayOptions?.template || props.field?.meta?.display_options?.template;
 
-  if (template && props.field?.display) {
+  let template: string | null | undefined = null;
+  let isOverridePath = false;
+
+  if (override?.template) {
+    template = override.template;
+    isOverridePath = true;
+  } else if (props.field?.display && fieldTemplate) {
+    template = fieldTemplate;
+  } else {
+    // Heuristic only fires for relational fields without override/field.display
+    const heuristic = pickHeuristic(props.field as any, relationsStore as any, fieldsStore as any);
+    if (heuristic) template = heuristic;
+  }
+
+  if (template) {
     const relationalValue = props.item[props.fieldKey];
 
-    // If we have an object, use it
-    if (relationalValue && typeof relationalValue === 'object') {
-      return renderTemplate(relationalValue, template);
+    // M2M unwrap when override active. For heuristic / field-display paths, the
+    // existing render path already handles the data shape correctly.
+    let valueForTemplate = relationalValue;
+    if (
+      isOverridePath &&
+      Array.isArray(relationalValue) &&
+      props.field?.meta?.special?.includes('m2m')
+    ) {
+      const collection = props.field?.collection;
+      const fieldName = props.field?.field;
+      if (collection && fieldName) {
+        const relations = relationsStore.getRelationsForField(collection, fieldName);
+        const junctionField = relations?.[0]?.meta?.junction_field;
+        if (junctionField) {
+          valueForTemplate = relationalValue
+            .map((item: any) => item?.[junctionField])
+            .filter(Boolean);
+        }
+      }
+    }
+
+    // If we have an array (M2M / O2M), render each item with the template and join
+    if (Array.isArray(valueForTemplate)) {
+      if (valueForTemplate.length === 0) return '—';
+      return valueForTemplate
+        .map((item: any) =>
+          item && typeof item === 'object' ? renderTemplate(item, template as string) : String(item)
+        )
+        .filter((s) => s && s !== '—')
+        .join(', ');
+    }
+
+    // Single object → render once
+    if (valueForTemplate && typeof valueForTemplate === 'object') {
+      return renderTemplate(valueForTemplate, template);
     }
 
     // If corrupted (primitive value), try cache fallback
@@ -313,6 +371,50 @@ const displayValue = computed(() => {
 
   // Simple field access
   return props.item[props.fieldKey];
+});
+
+type ResolvedDisplay = {
+  display: string | null;
+  options: Record<string, unknown>;
+  source: 'override' | 'field' | 'heuristic' | 'raw';
+};
+
+const resolvedDisplay = computed<ResolvedDisplay>(() => {
+  // Storage key for translations is the root (no language suffix)
+  const storageKey = props.fieldKey.includes(':') ? props.fieldKey.split(':')[0] : props.fieldKey;
+
+  // 1. Layout-level override (renders via related-values unless the user
+  //    explicitly stored a different display id alongside the template)
+  const override = props.columnDisplays?.[storageKey];
+  if (override?.template) {
+    return {
+      display: override.display ?? 'related-values',
+      options: { template: override.template },
+      source: 'override',
+    };
+  }
+
+  // 2. Field-settings display — pass the full options object so template-less
+  //    displays (image, color, formatted-value with prefix/suffix, ...) work.
+  if (props.field?.display) {
+    return {
+      display: props.field.display,
+      options: (props.field as any).displayOptions ?? props.field?.meta?.display_options ?? {},
+      source: 'field',
+    };
+  }
+
+  // 3. Smart heuristics for relational fields without any configured display
+  const heuristic = pickHeuristic(props.field as any, relationsStore as any, fieldsStore as any);
+  if (heuristic) {
+    return {
+      display: 'related-values',
+      options: { template: heuristic },
+      source: 'heuristic',
+    };
+  }
+
+  return { display: null, options: {}, source: 'raw' };
 });
 
 // Check if field is editable using the field support utility

--- a/src/components/EditableCellRelational.vue
+++ b/src/components/EditableCellRelational.vue
@@ -292,6 +292,7 @@ const displayValue = computed(() => {
 
   let template: string | null | undefined = null;
   let isOverridePath = false;
+  let isHeuristicPath = false;
 
   if (override?.template) {
     template = override.template;
@@ -301,20 +302,23 @@ const displayValue = computed(() => {
   } else {
     // Heuristic only fires for relational fields without override/field.display
     const heuristic = pickHeuristic(props.field as any, relationsStore as any, fieldsStore as any);
-    if (heuristic) template = heuristic;
+    if (heuristic) {
+      template = heuristic;
+      isHeuristicPath = true;
+    }
   }
 
   if (template) {
     const relationalValue = props.item[props.fieldKey];
 
-    // M2M unwrap when override active. For heuristic / field-display paths, the
-    // existing render path already handles the data shape correctly.
+    // M2M unwrap when override OR heuristic provides the template. (Field-display
+    // renders via the existing path which handles its own shape.)
     let valueForTemplate = relationalValue;
-    if (
-      isOverridePath &&
+    const needsM2MUnwrap =
+      (isOverridePath || isHeuristicPath) &&
       Array.isArray(relationalValue) &&
-      props.field?.meta?.special?.includes('m2m')
-    ) {
+      props.field?.meta?.special?.includes('m2m');
+    if (needsM2MUnwrap) {
       const collection = props.field?.collection;
       const fieldName = props.field?.field;
       if (collection && fieldName) {

--- a/src/composables/useAliasFields.ts
+++ b/src/composables/useAliasFields.ts
@@ -4,6 +4,11 @@ import { get } from '@directus/utils';
 // CORE IMPORTS
 import { adjustFieldsForDisplays } from '../utils/adjustFieldsForDisplays';
 
+interface ColumnDisplayLike {
+  template: string;
+  display?: string;
+}
+
 export type AliasFields =
   | {
       fieldName: string;
@@ -30,17 +35,22 @@ type UsableAliasFields = {
  * Generates aliases for field collisions when fetching the data for each display.
  * @param fields This list of fields to be aliased
  * @param collection The collection the fields belong to
+ * @param overrides Optional per-column display overrides (issue #48).
+ *                  Forwarded to `adjustFieldsForDisplays` so template tokens
+ *                  in overrides expand into deep API field requests.
  * @returns Info about the display fields and if the original fields were aliased
  */
 export function useAliasFields(
   fields: Ref<string[]> | string[],
-  collection: Ref<string | null> | string | null
+  collection: Ref<string | null> | string | null,
+  overrides?: Ref<Record<string, ColumnDisplayLike>> | Record<string, ColumnDisplayLike>
 ): UsableAliasFields {
   const aliasedFields = computed(() => {
     const aliasedFields: Record<string, AliasFields> = {};
 
     const _fields = unref(fields);
     const _collection = unref(collection);
+    const _overrides = unref(overrides) ?? {};
 
     if (!_fields || _fields.length === 0 || !_collection) return aliasedFields;
 
@@ -70,7 +80,7 @@ export function useAliasFields(
         aliasedFields[field] = {
           key: field,
           fieldName,
-          fields: adjustFieldsForDisplays([field], _collection),
+          fields: adjustFieldsForDisplays([field], _collection, _overrides),
           aliased: false,
         };
       } else {
@@ -79,7 +89,7 @@ export function useAliasFields(
         aliasedFields[field] = {
           key: field,
           fieldName,
-          fields: adjustFieldsForDisplays([field], _collection),
+          fields: adjustFieldsForDisplays([field], _collection, _overrides),
           aliased: false,
         };
       }

--- a/src/composables/useColumnDisplays.ts
+++ b/src/composables/useColumnDisplays.ts
@@ -1,0 +1,49 @@
+import { computed, type Ref } from 'vue';
+
+export interface ColumnDisplay {
+  template: string;
+  display?: string;
+}
+
+interface LayoutOptionsLike {
+  columnDisplays?: Record<string, ColumnDisplay>;
+  [key: string]: unknown;
+}
+
+/**
+ * Issue #48: CRUD wrapper for the per-layout columnDisplays map. Mutating a
+ * single entry rewrites the whole map so we trigger reactive watchers cleanly
+ * without partial-object surprises.
+ */
+export function useColumnDisplays(layoutOptions: Ref<LayoutOptionsLike>) {
+  const all = computed<Record<string, ColumnDisplay>>(
+    () => layoutOptions.value?.columnDisplays ?? {}
+  );
+
+  function getOverride(fieldKey: string): ColumnDisplay | null {
+    return all.value[fieldKey] ?? null;
+  }
+
+  function hasOverride(fieldKey: string): boolean {
+    return Object.prototype.hasOwnProperty.call(all.value, fieldKey);
+  }
+
+  function setOverride(fieldKey: string, value: ColumnDisplay): void {
+    const trimmed = value.template?.trim() ?? '';
+    if (trimmed.length === 0) {
+      removeOverride(fieldKey);
+      return;
+    }
+    const next = { ...all.value, [fieldKey]: { ...value, template: trimmed } };
+    layoutOptions.value = { ...layoutOptions.value, columnDisplays: next };
+  }
+
+  function removeOverride(fieldKey: string): void {
+    if (!hasOverride(fieldKey)) return;
+    const next = { ...all.value };
+    delete next[fieldKey];
+    layoutOptions.value = { ...layoutOptions.value, columnDisplays: next };
+  }
+
+  return { all, getOverride, hasOverride, setOverride, removeOverride };
+}

--- a/src/options.vue
+++ b/src/options.vue
@@ -33,11 +33,23 @@
       Custom field name for language codes in translation collections (default: 'languages_code')
     </div>
   </div>
+
+  <ColumnDisplaysSection
+    v-if="props.collection && props.availableFieldChoices && props.availableFieldChoices.length > 0"
+    :collection="props.collection"
+    :column-displays="columnDisplays"
+    :available-fields="props.availableFieldChoices"
+    @set="onSet"
+    @remove="onRemove"
+  />
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue';
+import { computed, type Ref } from 'vue';
 import { useSync } from '@directus/extensions-sdk';
+import ColumnDisplaysSection from './components/ColumnDisplaysSection.vue';
+import { useColumnDisplays } from './composables/useColumnDisplays';
+import type { ColumnDisplay } from './composables/useColumnDisplays';
 
 interface LayoutOptions {
   showToolbar?: boolean;
@@ -50,15 +62,31 @@ interface LayoutOptions {
   widths?: Record<string, number>;
   align?: Record<string, 'left' | 'center' | 'right'>;
   languageCodeField?: string;
+  columnDisplays?: Record<string, { template: string; display?: string }>;
 }
 
 const props = defineProps<{
   layoutOptions: LayoutOptions;
+  collection?: string;
+  availableFieldChoices?: Array<{ key: string; label: string }>;
 }>();
 
 const emit = defineEmits(['update:layoutOptions']);
 
 const layoutOptions = useSync(props, 'layoutOptions', emit);
+
+const {
+  all: columnDisplays,
+  setOverride,
+  removeOverride,
+} = useColumnDisplays(layoutOptions as unknown as Ref<LayoutOptions & { [key: string]: unknown }>);
+
+function onSet(payload: { fieldKey: string; display: ColumnDisplay }) {
+  setOverride(payload.fieldKey, payload.display);
+}
+function onRemove(fieldKey: string) {
+  removeOverride(fieldKey);
+}
 
 // General Settings
 const showToolbar = computed({

--- a/src/options.vue
+++ b/src/options.vue
@@ -83,17 +83,37 @@ const {
 
 function onSet(payload: { fieldKey: string; display: ColumnDisplay }) {
   setOverride(payload.fieldKey, payload.display);
+  scheduleTableRefresh();
 }
 function onRemove(fieldKey: string) {
   removeOverride(fieldKey);
+  scheduleTableRefresh();
 }
 
-// General Settings
+// After mutating columnDisplays we need the table to refetch with the new
+// override-driven deep paths. Reactivity propagates through the parent layout
+// asynchronously, so we dispatch a window event after the next tick — super-table.vue
+// listens for it and calls getItems() with fresh aliasedFields.
+function scheduleTableRefresh() {
+  setTimeout(() => {
+    window.dispatchEvent(new CustomEvent('super-layout-table:refresh'));
+  }, 0);
+}
+
+// Issue #48: read setters from `props.layoutOptions` instead of the synced ref.
+// `useSync` is essentially `{ get: () => props.x, set: (v) => emit('update:x', v) }`
+// — the local ref does NOT update synchronously after a write; it only updates
+// when the parent re-emits the new prop value back. If two setters fire in
+// rapid succession (e.g. setOverride from useColumnDisplays then editMode toggle),
+// the second one reads STALE state from layoutOptions.value and silently
+// overwrites the columnDisplays the first setter just wrote.
+// Fix: every setter spreads `props.layoutOptions` (always the latest prop value).
+
 const showToolbar = computed({
   get: () => layoutOptions.value?.showToolbar !== false,
   set: (val) => {
     layoutOptions.value = {
-      ...layoutOptions.value,
+      ...props.layoutOptions,
       showToolbar: val,
     };
   },
@@ -103,7 +123,7 @@ const editMode = computed({
   get: () => layoutOptions.value?.editMode === true,
   set: (val) => {
     layoutOptions.value = {
-      ...layoutOptions.value,
+      ...props.layoutOptions,
       editMode: val,
     };
   },
@@ -113,7 +133,7 @@ const directBooleanToggle = computed({
   get: () => layoutOptions.value?.directBooleanToggle === true,
   set: (val) => {
     layoutOptions.value = {
-      ...layoutOptions.value,
+      ...props.layoutOptions,
       directBooleanToggle: val,
     };
   },
@@ -123,7 +143,7 @@ const languageCodeField = computed({
   get: () => layoutOptions.value?.languageCodeField || 'languages_code',
   set: (val) => {
     layoutOptions.value = {
-      ...layoutOptions.value,
+      ...props.layoutOptions,
       languageCodeField: val || undefined, // Store undefined if empty to use default
     };
   },

--- a/src/options.vue
+++ b/src/options.vue
@@ -83,21 +83,9 @@ const {
 
 function onSet(payload: { fieldKey: string; display: ColumnDisplay }) {
   setOverride(payload.fieldKey, payload.display);
-  scheduleTableRefresh();
 }
 function onRemove(fieldKey: string) {
   removeOverride(fieldKey);
-  scheduleTableRefresh();
-}
-
-// After mutating columnDisplays we need the table to refetch with the new
-// override-driven deep paths. Reactivity propagates through the parent layout
-// asynchronously, so we dispatch a window event after the next tick — super-table.vue
-// listens for it and calls getItems() with fresh aliasedFields.
-function scheduleTableRefresh() {
-  setTimeout(() => {
-    window.dispatchEvent(new CustomEvent('super-layout-table:refresh'));
-  }, 0);
 }
 
 // Issue #48: read setters from `props.layoutOptions` instead of the synced ref.

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -273,7 +273,17 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, toRefs, watch, unref, onMounted, onUnmounted, type Ref } from 'vue';
+import {
+  ref,
+  computed,
+  toRefs,
+  watch,
+  unref,
+  nextTick,
+  onMounted,
+  onUnmounted,
+  type Ref,
+} from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import { debounce } from 'lodash';
@@ -931,6 +941,32 @@ async function handleQuickFilterSaved(event: any) {
   }
 }
 
+// Issue #48: when columnDisplays change locally, our own reactive chain handles
+// the rebuild AND the watch on fieldsWithRelational fires. But when the change
+// originates in options.vue (a sibling slot), the prop round-trip through the
+// parent layout takes a few ticks. We watch our own layoutOptions for changes
+// to the columnDisplays map and force a refetch after nextTick so aliasedFields
+// has fully settled.
+watch(
+  () => (layoutOptions.value as any)?.columnDisplays,
+  async () => {
+    await nextTick();
+    getItems();
+  },
+  { deep: true }
+);
+
+// Window-event fallback: options.vue dispatches this after setOverride/removeOverride.
+// Helps in cases where the prop sync hasn't propagated by the time our local
+// watch (above) would have fired. Both paths converge on the same getItems call;
+// directus' API layer dedupes in-flight requests so this isn't a double-fetch.
+function handleColumnDisplaysChanged() {
+  // 250ms ≈ enough for the options.vue → parent layout → super-table.vue prop
+  // round-trip to land. Microtask-precise nextTick is too eager here because
+  // the round-trip spans a full event-loop turn (parent re-render).
+  setTimeout(() => getItems(), 250);
+}
+
 // Setup event listeners on mount
 onMounted(() => {
   // Load presets from layoutOptions (no localStorage needed)
@@ -941,10 +977,12 @@ onMounted(() => {
 
   // Listen for save events from actions
   window.addEventListener('quick-filter-saved', handleQuickFilterSaved);
+  window.addEventListener('super-layout-table:refresh', handleColumnDisplaysChanged);
 });
 
 onUnmounted(() => {
   window.removeEventListener('quick-filter-saved', handleQuickFilterSaved);
+  window.removeEventListener('super-layout-table:refresh', handleColumnDisplaysChanged);
 });
 
 // Update manual filters when props.filter changes (from native filter interface)

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -211,6 +211,7 @@
           :direct-boolean-toggle="(layoutOptions as any)?.directBooleanToggle"
           :primary-key-field-name="getPrimaryKeyFieldName()"
           :language-code-field="translationConfig.languageCodeField"
+          :column-displays="(layoutOptions as any)?.columnDisplays"
           @update="updateFieldValue"
           @save="autoSaveEdits"
         />
@@ -471,10 +472,16 @@ const fieldsForAliasing = computed(() => {
   });
 });
 
-// Use alias fields for proper relational data handling
+// Use alias fields for proper relational data handling.
+// Issue #48: forward the columnDisplays override map so the API query expands
+// override template paths (e.g. `{{ user.first_name }}`) into deep field
+// requests via `adjustFieldsForDisplays`.
+const columnDisplaysRef = computed(() => (layoutOptions.value as any)?.columnDisplays ?? {});
+
 const { aliasedFields, aliasQuery, getFromAliasedItem } = useAliasFields(
   fieldsForAliasing,
-  collection
+  collection,
+  columnDisplaysRef
 );
 
 // Create fields for API query using the aliased fields (following original Directus pattern)

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -273,24 +273,14 @@
 </template>
 
 <script lang="ts" setup>
-import {
-  ref,
-  computed,
-  toRefs,
-  watch,
-  unref,
-  nextTick,
-  onMounted,
-  onUnmounted,
-  type Ref,
-} from 'vue';
+import { ref, computed, toRefs, watch, unref, onMounted, onUnmounted, type Ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import { debounce } from 'lodash';
 import { useStores, useCollection, useSync, useApi } from '@directus/extensions-sdk';
 import { formatTitle } from '@directus/format-title';
 import { getDefaultDisplayForType } from './utils/getDefaultDisplayForType';
-import { filterValidFields } from './utils/fieldValidity';
+import { filterValidFields, filterValidColumnDisplays } from './utils/fieldValidity';
 import { useTableApi } from './composables/api';
 import { useAliasFields } from './composables/useAliasFields';
 import { useLanguageSelector } from './composables/useLanguageSelector';
@@ -485,8 +475,16 @@ const fieldsForAliasing = computed(() => {
 // Use alias fields for proper relational data handling.
 // Issue #48: forward the columnDisplays override map so the API query expands
 // override template paths (e.g. `{{ user.first_name }}`) into deep field
-// requests via `adjustFieldsForDisplays`.
-const columnDisplaysRef = computed(() => (layoutOptions.value as any)?.columnDisplays ?? {});
+// requests via `adjustFieldsForDisplays`. Drop entries that point at fields
+// the user has since deleted from the collection (mirrors filterValidFields).
+type ColumnDisplayShape = { template: string; display?: string };
+const columnDisplaysRef = computed(() =>
+  filterValidColumnDisplays<ColumnDisplayShape>(
+    (layoutOptions.value as any)?.columnDisplays,
+    collection.value,
+    fieldsStore
+  )
+);
 
 const { aliasedFields, aliasQuery, getFromAliasedItem } = useAliasFields(
   fieldsForAliasing,
@@ -941,31 +939,17 @@ async function handleQuickFilterSaved(event: any) {
   }
 }
 
-// Issue #48: when columnDisplays change locally, our own reactive chain handles
-// the rebuild AND the watch on fieldsWithRelational fires. But when the change
-// originates in options.vue (a sibling slot), the prop round-trip through the
-// parent layout takes a few ticks. We watch our own layoutOptions for changes
-// to the columnDisplays map and force a refetch after nextTick so aliasedFields
-// has fully settled.
+// Issue #48: when columnDisplays change in options.vue (sibling slot), the prop
+// round-trip through the parent layout takes a few ticks. flush: 'post' makes
+// the watcher run after the DOM update so aliasedFields has fully settled
+// before we refetch.
 watch(
   () => (layoutOptions.value as any)?.columnDisplays,
-  async () => {
-    await nextTick();
+  () => {
     getItems();
   },
-  { deep: true }
+  { deep: true, flush: 'post' }
 );
-
-// Window-event fallback: options.vue dispatches this after setOverride/removeOverride.
-// Helps in cases where the prop sync hasn't propagated by the time our local
-// watch (above) would have fired. Both paths converge on the same getItems call;
-// directus' API layer dedupes in-flight requests so this isn't a double-fetch.
-function handleColumnDisplaysChanged() {
-  // 250ms ≈ enough for the options.vue → parent layout → super-table.vue prop
-  // round-trip to land. Microtask-precise nextTick is too eager here because
-  // the round-trip spans a full event-loop turn (parent re-render).
-  setTimeout(() => getItems(), 250);
-}
 
 // Setup event listeners on mount
 onMounted(() => {
@@ -977,12 +961,10 @@ onMounted(() => {
 
   // Listen for save events from actions
   window.addEventListener('quick-filter-saved', handleQuickFilterSaved);
-  window.addEventListener('super-layout-table:refresh', handleColumnDisplaysChanged);
 });
 
 onUnmounted(() => {
   window.removeEventListener('quick-filter-saved', handleQuickFilterSaved);
-  window.removeEventListener('super-layout-table:refresh', handleColumnDisplaysChanged);
 });
 
 // Update manual filters when props.filter changes (from native filter interface)

--- a/src/utils/adjustFieldsForDisplays.ts
+++ b/src/utils/adjustFieldsForDisplays.ts
@@ -128,23 +128,36 @@ function getDisplayFieldsForRelation(
  * This function replicates the core logic from Directus core for proper display field resolution.
  * Enhanced with field existence validation to prevent requesting non-existent fields.
  */
+// Module-level store cache. `useStores()` only works inside an active Vue
+// setup context. When `adjustFieldsForDisplays` is invoked from a reactive
+// recomputation (e.g. our `aliasedFields` computed reruns after columnDisplays
+// changes), the call may be outside the setup window — useStores() throws and
+// the function would otherwise fall back to returning the raw input fields,
+// which silently drops all path-expansion (override / heuristic / display).
+// We capture the singleton stores on the first successful call and reuse them.
+let cachedFieldsStore: any = null;
+let cachedRelationsStore: any = null;
+
+function ensureStores(): { fieldsStore: any; relationsStore: any } {
+  if (cachedFieldsStore && cachedRelationsStore) {
+    return { fieldsStore: cachedFieldsStore, relationsStore: cachedRelationsStore };
+  }
+  try {
+    const { useFieldsStore, useRelationsStore } = useStores();
+    cachedFieldsStore = useFieldsStore();
+    cachedRelationsStore = useRelationsStore();
+  } catch {
+    /* stores not yet available — caller falls back to returning raw fields */
+  }
+  return { fieldsStore: cachedFieldsStore, relationsStore: cachedRelationsStore };
+}
+
 export function adjustFieldsForDisplays(
   fields: readonly string[],
   parentCollection: string,
   overrides: Record<string, ColumnDisplay> = {}
 ): string[] {
-  // Get the stores, but handle the case where they're not available
-  let fieldsStore: any = null;
-  let relationsStore: any = null;
-  try {
-    const { useFieldsStore, useRelationsStore } = useStores();
-    fieldsStore = useFieldsStore();
-    relationsStore = useRelationsStore();
-  } catch {
-    // Stores not available, return original fields
-    return [...fields];
-  }
-
+  const { fieldsStore, relationsStore } = ensureStores();
   if (!fieldsStore) return [...fields];
 
   const adjustedFields: string[] = fields

--- a/src/utils/adjustFieldsForDisplays.ts
+++ b/src/utils/adjustFieldsForDisplays.ts
@@ -1,7 +1,7 @@
 // CORE CHANGES - Following original Directus approach
 import { useStores, useCollection } from '@directus/extensions-sdk';
 import type { ColumnDisplay } from '../composables/useColumnDisplays';
-import { parseTemplateTokens, isRelational } from './displayHeuristics';
+import { parseTemplateTokens, isRelational, pickHeuristic } from './displayHeuristics';
 
 /**
  * Helper function to get the related collection for a field
@@ -182,6 +182,36 @@ export function adjustFieldsForDisplays(
 
         // M2O / O2M / files: direct dotted paths
         return tokens.map((tok) => `${fieldKey}.${tok}`);
+      }
+
+      // Heuristic branch (Issue #48): when no override exists, the field is
+      // relational, AND no field-settings display is configured, derive a sensible
+      // template via pickHeuristic and expand API paths the same way as override.
+      const fieldDefForHeuristic = fieldsStore.getField(parentCollection, fieldKey);
+      if (
+        fieldDefForHeuristic &&
+        !fieldDefForHeuristic.meta?.display &&
+        isRelational(fieldDefForHeuristic) &&
+        !fieldDefForHeuristic.meta?.special?.includes('translations')
+      ) {
+        const heuristicTemplate = relationsStore
+          ? pickHeuristic(fieldDefForHeuristic, relationsStore as any, fieldsStore as any)
+          : null;
+        if (heuristicTemplate) {
+          const heuristicTokens = parseTemplateTokens(heuristicTemplate);
+          if (heuristicTokens.length > 0) {
+            const isM2M = fieldDefForHeuristic.meta?.special?.includes('m2m');
+            if (isM2M) {
+              const relations = relationsStore?.getRelationsForField(parentCollection, fieldKey);
+              const junctionField = relations?.[0]?.meta?.junction_field;
+              if (junctionField) {
+                return heuristicTokens.map((tok) => `${fieldKey}.${junctionField}.${tok}`);
+              }
+              return [`${fieldKey}.${heuristicTokens[0]}`];
+            }
+            return heuristicTokens.map((tok) => `${fieldKey}.${tok}`);
+          }
+        }
       }
 
       const field = fieldsStore.getField(parentCollection, fieldKey);

--- a/src/utils/adjustFieldsForDisplays.ts
+++ b/src/utils/adjustFieldsForDisplays.ts
@@ -1,6 +1,7 @@
 // CORE CHANGES - Following original Directus approach
 import { useStores, useCollection } from '@directus/extensions-sdk';
 import type { ColumnDisplay } from '../composables/useColumnDisplays';
+import { parseTemplateTokens, isRelational } from './displayHeuristics';
 
 /**
  * Helper function to get the related collection for a field
@@ -132,10 +133,6 @@ export function adjustFieldsForDisplays(
   parentCollection: string,
   overrides: Record<string, ColumnDisplay> = {}
 ): string[] {
-  // Issue #48: `overrides` is wired into the .map() in Task 7. Reference it here
-  // to satisfy noUnusedParameters without changing behavior.
-  void overrides;
-
   // Get the stores, but handle the case where they're not available
   let fieldsStore: any = null;
   let relationsStore: any = null;
@@ -152,6 +149,41 @@ export function adjustFieldsForDisplays(
 
   const adjustedFields: string[] = fields
     .map((fieldKey) => {
+      // Issue #48: Override branch
+      //
+      // Storage normalization: layoutOptions.columnDisplays uses the *root* key
+      // (translations.title), but layoutQuery.fields entries can carry a language
+      // suffix (translations.title:de-DE). Strip the suffix before lookup so a
+      // single override applies to every language column for the same root field.
+      const storageKey = fieldKey.includes(':') ? fieldKey.split(':')[0] : fieldKey;
+      const override = overrides[storageKey];
+      if (override?.template) {
+        const tokens = parseTemplateTokens(override.template);
+        if (tokens.length === 0) return fieldKey;
+
+        const fieldDef = fieldsStore.getField(parentCollection, fieldKey);
+
+        // Plain field: tokens are already resolved at the parent level — return fieldKey
+        // (the template references the field's own value; no path expansion needed).
+        if (!isRelational(fieldDef)) {
+          return fieldKey;
+        }
+
+        // M2M: paths must traverse the junction's junction_field.
+        const isM2M = fieldDef?.meta?.special?.includes('m2m');
+        if (isM2M) {
+          const relations = relationsStore?.getRelationsForField(parentCollection, fieldKey);
+          const junctionField = relations?.[0]?.meta?.junction_field;
+          if (junctionField) {
+            return tokens.map((tok) => `${fieldKey}.${junctionField}.${tok}`);
+          }
+          return [`${fieldKey}.${tokens[0]}`]; // best-effort fallback
+        }
+
+        // M2O / O2M / files: direct dotted paths
+        return tokens.map((tok) => `${fieldKey}.${tok}`);
+      }
+
       const field = fieldsStore.getField(parentCollection, fieldKey);
 
       if (!field) return fieldKey;

--- a/src/utils/adjustFieldsForDisplays.ts
+++ b/src/utils/adjustFieldsForDisplays.ts
@@ -1,5 +1,6 @@
 // CORE CHANGES - Following original Directus approach
 import { useStores, useCollection } from '@directus/extensions-sdk';
+import type { ColumnDisplay } from '../composables/useColumnDisplays';
 
 /**
  * Helper function to get the related collection for a field
@@ -128,8 +129,13 @@ function getDisplayFieldsForRelation(
  */
 export function adjustFieldsForDisplays(
   fields: readonly string[],
-  parentCollection: string
+  parentCollection: string,
+  overrides: Record<string, ColumnDisplay> = {}
 ): string[] {
+  // Issue #48: `overrides` is wired into the .map() in Task 7. Reference it here
+  // to satisfy noUnusedParameters without changing behavior.
+  void overrides;
+
   // Get the stores, but handle the case where they're not available
   let fieldsStore: any = null;
   let relationsStore: any = null;

--- a/src/utils/displayHeuristics.ts
+++ b/src/utils/displayHeuristics.ts
@@ -1,0 +1,27 @@
+/**
+ * Issue #48: pure helpers for resolving display templates and target collections
+ * for relational fields when the user has not configured an override or a field
+ * display in collection settings.
+ */
+
+const RELATIONAL_SPECIALS = ['m2o', 'o2m', 'm2m', 'm2a', 'files', 'translations'] as const;
+
+export function isRelational(field: { meta?: { special?: string[] } } | null | undefined): boolean {
+  if (!field?.meta?.special) return false;
+  return field.meta.special.some((s) => (RELATIONAL_SPECIALS as readonly string[]).includes(s));
+}
+
+/**
+ * Pull the field tokens out of a display template. Whitespace is stripped,
+ * duplicates are removed, dotted paths are kept intact (callers decide whether
+ * to flatten them).
+ */
+export function parseTemplateTokens(template: string): string[] {
+  if (!template) return [];
+  const matches = template.match(/\{\{\s*([^}]+?)\s*\}\}/g);
+  if (!matches) return [];
+  const fields = matches
+    .map((m) => m.replace(/\{\{\s*|\s*\}\}/g, '').trim())
+    .filter((f) => f.length > 0);
+  return [...new Set(fields)];
+}

--- a/src/utils/displayHeuristics.ts
+++ b/src/utils/displayHeuristics.ts
@@ -89,3 +89,36 @@ export function resolveTargetCollection(
   // Pure O2M: the related collection IS the target
   return rel.collection ?? null;
 }
+
+const HEURISTIC_FALLBACK_FIELDS = ['name', 'title', 'label'] as const;
+
+export function pickHeuristic(
+  field: { collection?: string; field?: string; meta?: { special?: string[] } } | null,
+  relationsStore: RelationsStoreLike,
+  fieldsStore: FieldsStoreLike
+): string | null {
+  if (!isRelational(field)) return null;
+
+  // Translations have their own client-side rendering path in EditableCellRelational
+  // (language-filtered before display). Heuristics would interfere; skip them.
+  if (field?.meta?.special?.includes('translations')) return null;
+
+  const target = resolveTargetCollection(field, relationsStore, fieldsStore);
+  if (!target) return null;
+
+  if (target === 'directus_users') {
+    return '{{first_name}} {{last_name}}';
+  }
+
+  if (target === 'directus_files') {
+    return fieldsStore.getField(target, 'title') ? '{{title}}' : '{{filename_download}}';
+  }
+
+  for (const candidate of HEURISTIC_FALLBACK_FIELDS) {
+    if (fieldsStore.getField(target, candidate)) {
+      return `{{${candidate}}}`;
+    }
+  }
+
+  return null;
+}

--- a/src/utils/displayHeuristics.ts
+++ b/src/utils/displayHeuristics.ts
@@ -25,3 +25,67 @@ export function parseTemplateTokens(template: string): string[] {
     .filter((f) => f.length > 0);
   return [...new Set(fields)];
 }
+
+interface RelationsStoreLike {
+  getRelationsForField: (
+    collection: string,
+    field: string
+  ) => Array<{
+    collection?: string;
+    field?: string;
+    related_collection?: string | null;
+    meta?: { junction_field?: string | null } | null;
+  }>;
+}
+
+interface FieldsStoreLike {
+  getField: (
+    collection: string | null,
+    field: string
+  ) => { schema?: { foreign_key_table?: string | null } | null } | null | undefined;
+}
+
+/**
+ * Resolves the display-target collection for a relational field.
+ *
+ *   M2O           → relation.related_collection
+ *   O2M (no junction) → relation.collection (the related table)
+ *   M2M (with junction) → traverse junction.junction_field to get its target table
+ *   M2A           → not supported in heuristics; returns null
+ */
+export function resolveTargetCollection(
+  field: { collection?: string; field?: string; meta?: { special?: string[] } } | null,
+  relationsStore: RelationsStoreLike,
+  fieldsStore: FieldsStoreLike
+): string | null {
+  if (!field?.collection || !field.field) return null;
+  if (!isRelational(field)) return null;
+
+  const relations = relationsStore.getRelationsForField(field.collection, field.field);
+  const rel = relations?.[0];
+  if (!rel) return null;
+
+  // M2O: parent owns the FK
+  if (rel.collection === field.collection && rel.related_collection) {
+    return rel.related_collection;
+  }
+
+  // Translations also carry meta.junction_field (languages_code), but the
+  // intended target is the translations collection — never traverse the junction
+  // for translation fields.
+  if (field.meta?.special?.includes('translations')) {
+    return rel.collection ?? null;
+  }
+
+  // M2M: junction relation has junction_field pointing at the target FK
+  if (rel.meta?.junction_field) {
+    const junctionCollection = rel.collection;
+    const junctionField = rel.meta.junction_field;
+    if (!junctionCollection) return null;
+    const junctionFieldDef = fieldsStore.getField(junctionCollection, junctionField);
+    return junctionFieldDef?.schema?.foreign_key_table ?? null;
+  }
+
+  // Pure O2M: the related collection IS the target
+  return rel.collection ?? null;
+}

--- a/src/utils/fieldValidity.ts
+++ b/src/utils/fieldValidity.ts
@@ -94,3 +94,22 @@ export function filterValidSort(
   if (!sortEntries || sortEntries.length === 0) return [];
   return sortEntries.filter((s) => isSortFieldValid(s, collection, fieldsStore));
 }
+
+/**
+ * Issue #48: drop columnDisplays entries pointing at fields that have been
+ * deleted from the collection. Mirrors filterValidFields / filterValidSort.
+ */
+export function filterValidColumnDisplays<T>(
+  columnDisplays: Record<string, T> | null | undefined,
+  collection: string | null,
+  fieldsStore: FieldsStoreLike
+): Record<string, T> {
+  if (!columnDisplays || !collection) return {};
+  const result: Record<string, T> = {};
+  for (const [key, value] of Object.entries(columnDisplays)) {
+    if (isFieldValid(key, collection, fieldsStore)) {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -42,6 +42,33 @@ vi.mock('@/stores', () => ({
   useCollectionStore: () => mockCollectionStore,
 }));
 
+// Mock the extensions-sdk to keep the real module (and its transitive @directus/themes
+// → pinia chain) out of the test runtime. Individual tests can override via
+// vi.doMock + vi.resetModules() if they need richer behavior.
+vi.mock('@directus/extensions-sdk', () => ({
+  useStores: () => ({
+    useFieldsStore: () => mockFieldsStore,
+    useRelationsStore: () => mockRelationsStore,
+    useCollectionStore: () => mockCollectionStore,
+  }),
+  useCollection: () => ({ primaryKeyField: { value: { field: 'id' } } }),
+  useApi: () => ({
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  }),
+  useSync: <T,>(props: Record<string, T>, key: string, emit: (e: string, v: T) => void) => ({
+    get value(): T {
+      return props[key]!;
+    },
+    set value(v: T) {
+      emit(`update:${key}`, v);
+    },
+  }),
+  defineLayout: vi.fn(),
+}));
+
 // Mock Directus SDK
 vi.mock('@directus/sdk', () => ({
   createDirectus: vi.fn(),

--- a/tests/unit/composables/useColumnDisplays.test.ts
+++ b/tests/unit/composables/useColumnDisplays.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { useColumnDisplays } from '@/composables/useColumnDisplays';
+
+describe('useColumnDisplays', () => {
+  function makeLayoutOptions(initial: Record<string, any> = {}) {
+    return ref({ ...initial });
+  }
+
+  it('exposes existing entries via getOverride / hasOverride', () => {
+    const opts = makeLayoutOptions({
+      columnDisplays: {
+        author: { template: '{{first_name}}' },
+      },
+    });
+    const cd = useColumnDisplays(opts as any);
+    expect(cd.hasOverride('author')).toBe(true);
+    expect(cd.getOverride('author')).toEqual({ template: '{{first_name}}' });
+    expect(cd.hasOverride('title')).toBe(false);
+    expect(cd.getOverride('title')).toBe(null);
+  });
+
+  it('returns empty map when columnDisplays is undefined', () => {
+    const opts = makeLayoutOptions();
+    const cd = useColumnDisplays(opts as any);
+    expect(cd.all.value).toEqual({});
+  });
+
+  it('setOverride writes a new entry into layoutOptions', () => {
+    const opts = makeLayoutOptions();
+    const cd = useColumnDisplays(opts as any);
+    cd.setOverride('tags', { template: '{{name}}' });
+    expect(opts.value.columnDisplays).toEqual({ tags: { template: '{{name}}' } });
+  });
+
+  it('setOverride replaces an existing entry', () => {
+    const opts = makeLayoutOptions({
+      columnDisplays: { author: { template: '{{first_name}}' } },
+    });
+    const cd = useColumnDisplays(opts as any);
+    cd.setOverride('author', { template: '{{first_name}} {{last_name}}' });
+    expect(opts.value.columnDisplays.author).toEqual({
+      template: '{{first_name}} {{last_name}}',
+    });
+  });
+
+  it('removeOverride deletes an entry', () => {
+    const opts = makeLayoutOptions({
+      columnDisplays: {
+        author: { template: '{{first_name}}' },
+        tags: { template: '{{name}}' },
+      },
+    });
+    const cd = useColumnDisplays(opts as any);
+    cd.removeOverride('author');
+    expect(opts.value.columnDisplays).toEqual({ tags: { template: '{{name}}' } });
+  });
+
+  it('setOverride with empty/whitespace template removes the entry', () => {
+    const opts = makeLayoutOptions({
+      columnDisplays: { author: { template: '{{x}}' } },
+    });
+    const cd = useColumnDisplays(opts as any);
+    cd.setOverride('author', { template: '   ' });
+    expect(opts.value.columnDisplays).toEqual({});
+  });
+
+  it('all is reactive — updates when layoutOptions changes externally', () => {
+    const opts = makeLayoutOptions();
+    const cd = useColumnDisplays(opts as any);
+    expect(cd.all.value).toEqual({});
+    opts.value = {
+      columnDisplays: { tags: { template: '{{name}}' } },
+    };
+    expect(cd.all.value).toEqual({ tags: { template: '{{name}}' } });
+  });
+});

--- a/tests/unit/utils/adjustFieldsForDisplays.test.ts
+++ b/tests/unit/utils/adjustFieldsForDisplays.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+
+// Note: adjustFieldsForDisplays uses useStores() at runtime which we mock in
+// tests/setup.ts. With those mocks, calling it with no overrides should return
+// the original fields unchanged when the store has no field metadata.
+
+describe('adjustFieldsForDisplays', () => {
+  it('accepts overrides as an optional third parameter', async () => {
+    const { adjustFieldsForDisplays } = await import('@/utils/adjustFieldsForDisplays');
+    // Just call with overrides — the signature should accept it
+    const result = adjustFieldsForDisplays(['title', 'tags'], 'parent', {});
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it('returns input fields when no overrides and no field metadata', async () => {
+    const { adjustFieldsForDisplays } = await import('@/utils/adjustFieldsForDisplays');
+    const result = adjustFieldsForDisplays(['title'], 'parent');
+    expect(result).toContain('title');
+  });
+});

--- a/tests/unit/utils/adjustFieldsForDisplays.test.ts
+++ b/tests/unit/utils/adjustFieldsForDisplays.test.ts
@@ -4,6 +4,11 @@ import { vi } from 'vitest';
 // Note: adjustFieldsForDisplays uses useStores() at runtime which we mock in
 // tests/setup.ts. With those mocks, calling it with no overrides should return
 // the original fields unchanged when the store has no field metadata.
+// Reset modules before every test so the module-level store cache in
+// adjustFieldsForDisplays.ts cannot leak between tests.
+beforeEach(() => {
+  vi.resetModules();
+});
 
 describe('adjustFieldsForDisplays', () => {
   it('accepts overrides as an optional third parameter', async () => {

--- a/tests/unit/utils/adjustFieldsForDisplays.test.ts
+++ b/tests/unit/utils/adjustFieldsForDisplays.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { vi } from 'vitest';
 
 // Note: adjustFieldsForDisplays uses useStores() at runtime which we mock in
 // tests/setup.ts. With those mocks, calling it with no overrides should return
@@ -16,5 +17,66 @@ describe('adjustFieldsForDisplays', () => {
     const { adjustFieldsForDisplays } = await import('@/utils/adjustFieldsForDisplays');
     const result = adjustFieldsForDisplays(['title'], 'parent');
     expect(result).toContain('title');
+  });
+});
+
+describe('adjustFieldsForDisplays — override path', () => {
+  beforeEach(() => {
+    // Re-mock fields/relations stores so we can assert what gets requested
+    vi.resetModules();
+  });
+
+  it('expands template fields for a plain-field override', async () => {
+    vi.doMock('@directus/extensions-sdk', () => ({
+      useStores: () => ({
+        useFieldsStore: () => ({
+          getField: (col: string, f: string) =>
+            f === 'title' ? { field: 'title', meta: {} } : null,
+          getFieldsForCollection: () => [],
+        }),
+        useRelationsStore: () => ({
+          getRelationsForField: () => [],
+        }),
+      }),
+      useCollection: () => ({ primaryKeyField: { value: { field: 'id' } } }),
+    }));
+    const { adjustFieldsForDisplays } = await import('@/utils/adjustFieldsForDisplays');
+    const result = adjustFieldsForDisplays(
+      ['title'],
+      'parent',
+      { title: { template: '{{title}}' } }
+    );
+    expect(result).toContain('title');
+  });
+
+  it('expands m2o override to dotted target paths', async () => {
+    vi.doMock('@directus/extensions-sdk', () => ({
+      useStores: () => ({
+        useFieldsStore: () => ({
+          getField: (col: string, f: string) => {
+            if (col === 'parent' && f === 'author')
+              return { field: 'author', meta: { special: ['m2o'] }, collection: 'parent' };
+            if (col === 'directus_users' && (f === 'first_name' || f === 'last_name'))
+              return { field: f };
+            return null;
+          },
+          getFieldsForCollection: () => [],
+        }),
+        useRelationsStore: () => ({
+          getRelationsForField: (col: string, f: string) =>
+            col === 'parent' && f === 'author'
+              ? [{ collection: 'parent', field: 'author', related_collection: 'directus_users' }]
+              : [],
+        }),
+      }),
+      useCollection: () => ({ primaryKeyField: { value: { field: 'id' } } }),
+    }));
+    const { adjustFieldsForDisplays } = await import('@/utils/adjustFieldsForDisplays');
+    const result = adjustFieldsForDisplays(
+      ['author'],
+      'parent',
+      { author: { template: '{{first_name}} {{last_name}}' } }
+    );
+    expect(result).toEqual(expect.arrayContaining(['author.first_name', 'author.last_name']));
   });
 });

--- a/tests/unit/utils/displayHeuristics.test.ts
+++ b/tests/unit/utils/displayHeuristics.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { isRelational, parseTemplateTokens, resolveTargetCollection } from '@/utils/displayHeuristics';
+import {
+  isRelational,
+  parseTemplateTokens,
+  resolveTargetCollection,
+  pickHeuristic,
+} from '@/utils/displayHeuristics';
 
 describe('isRelational', () => {
   it('returns true when meta.special includes m2o, o2m, m2m, m2a, files, translations', () => {
@@ -129,5 +134,119 @@ describe('resolveTargetCollection', () => {
     expect(resolveTargetCollection(field, relations as any, fields as any)).toBe(
       'parent_translations'
     );
+  });
+});
+
+describe('pickHeuristic', () => {
+  it('returns null for non-relational fields', () => {
+    const relations = { getRelationsForField: () => [] };
+    const fields = { getField: () => null };
+    const field = { meta: { special: [] } } as any;
+    expect(pickHeuristic(field, relations as any, fields as any)).toBe(null);
+  });
+
+  it('uses first_name + last_name for directus_users targets', () => {
+    const relations = {
+      getRelationsForField: () => [
+        { collection: 'parent', field: 'author', related_collection: 'directus_users' },
+      ],
+    };
+    const fields = { getField: () => ({ field: 'first_name' }) };
+    const field = {
+      collection: 'parent',
+      field: 'author',
+      meta: { special: ['m2o'] },
+    } as any;
+    expect(pickHeuristic(field, relations as any, fields as any)).toBe(
+      '{{first_name}} {{last_name}}'
+    );
+  });
+
+  it('uses {{title}} for directus_files when title exists', () => {
+    const relations = {
+      getRelationsForField: () => [
+        { collection: 'parent', field: 'avatar', related_collection: 'directus_files' },
+      ],
+    };
+    const fields = {
+      getField: (col: string, f: string) => (f === 'title' ? { field: 'title' } : null),
+    };
+    const field = {
+      collection: 'parent',
+      field: 'avatar',
+      meta: { special: ['files'] },
+    } as any;
+    expect(pickHeuristic(field, relations as any, fields as any)).toBe('{{title}}');
+  });
+
+  it('falls back to {{filename_download}} for directus_files without title', () => {
+    const relations = {
+      getRelationsForField: () => [
+        { collection: 'parent', field: 'avatar', related_collection: 'directus_files' },
+      ],
+    };
+    const fields = { getField: () => null };
+    const field = {
+      collection: 'parent',
+      field: 'avatar',
+      meta: { special: ['files'] },
+    } as any;
+    expect(pickHeuristic(field, relations as any, fields as any)).toBe('{{filename_download}}');
+  });
+
+  it('tries name → title → label on a custom collection', () => {
+    let getFieldCalls = 0;
+    const relations = {
+      getRelationsForField: () => [
+        { collection: 'parent', field: 'category', related_collection: 'categories' },
+      ],
+    };
+    const fields = {
+      getField: (col: string, f: string) => {
+        getFieldCalls++;
+        return f === 'title' ? { field: 'title' } : null;
+      },
+    };
+    const field = {
+      collection: 'parent',
+      field: 'category',
+      meta: { special: ['m2o'] },
+    } as any;
+    expect(pickHeuristic(field, relations as any, fields as any)).toBe('{{title}}');
+  });
+
+  it('returns null when no heuristic matches', () => {
+    const relations = {
+      getRelationsForField: () => [
+        { collection: 'parent', field: 'thing', related_collection: 'things' },
+      ],
+    };
+    const fields = { getField: () => null };
+    const field = {
+      collection: 'parent',
+      field: 'thing',
+      meta: { special: ['m2o'] },
+    } as any;
+    expect(pickHeuristic(field, relations as any, fields as any)).toBe(null);
+  });
+
+  it('returns null for translation fields (existing render path handles them)', () => {
+    const relations = {
+      getRelationsForField: () => [
+        {
+          collection: 'parent_translations',
+          field: 'parent_id',
+          related_collection: 'parent',
+          meta: { junction_field: 'languages_code' },
+        },
+      ],
+    };
+    const fields = { getField: () => ({ field: 'title' }) };
+    const field = {
+      collection: 'parent',
+      field: 'translations',
+      meta: { special: ['translations'] },
+    } as any;
+    expect(pickHeuristic(field, relations as any, fields as any)).toBe(null);
   });
 });

--- a/tests/unit/utils/displayHeuristics.test.ts
+++ b/tests/unit/utils/displayHeuristics.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { isRelational, parseTemplateTokens } from '@/utils/displayHeuristics';
+
+describe('isRelational', () => {
+  it('returns true when meta.special includes m2o, o2m, m2m, m2a, files, translations', () => {
+    expect(isRelational({ meta: { special: ['m2o'] } } as any)).toBe(true);
+    expect(isRelational({ meta: { special: ['o2m'] } } as any)).toBe(true);
+    expect(isRelational({ meta: { special: ['m2m'] } } as any)).toBe(true);
+    expect(isRelational({ meta: { special: ['m2a'] } } as any)).toBe(true);
+    expect(isRelational({ meta: { special: ['files'] } } as any)).toBe(true);
+    expect(isRelational({ meta: { special: ['translations'] } } as any)).toBe(true);
+  });
+
+  it('returns false for plain fields', () => {
+    expect(isRelational({ meta: { special: [] } } as any)).toBe(false);
+    expect(isRelational({ meta: {} } as any)).toBe(false);
+    expect(isRelational({} as any)).toBe(false);
+    expect(isRelational(null as any)).toBe(false);
+  });
+});
+
+describe('parseTemplateTokens', () => {
+  it('extracts simple field tokens', () => {
+    expect(parseTemplateTokens('{{name}}')).toEqual(['name']);
+    expect(parseTemplateTokens('{{first_name}} {{last_name}}')).toEqual([
+      'first_name',
+      'last_name',
+    ]);
+  });
+
+  it('handles whitespace inside the braces', () => {
+    expect(parseTemplateTokens('{{ name }}')).toEqual(['name']);
+    expect(parseTemplateTokens('{{  name  }}')).toEqual(['name']);
+  });
+
+  it('extracts nested paths as-is (caller decides what to do with them)', () => {
+    expect(parseTemplateTokens('{{author.first_name}}')).toEqual(['author.first_name']);
+  });
+
+  it('returns [] for templates with no tokens', () => {
+    expect(parseTemplateTokens('plain text')).toEqual([]);
+    expect(parseTemplateTokens('')).toEqual([]);
+  });
+
+  it('deduplicates repeated tokens', () => {
+    expect(parseTemplateTokens('{{name}} - {{name}}')).toEqual(['name']);
+  });
+});

--- a/tests/unit/utils/displayHeuristics.test.ts
+++ b/tests/unit/utils/displayHeuristics.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isRelational, parseTemplateTokens } from '@/utils/displayHeuristics';
+import { isRelational, parseTemplateTokens, resolveTargetCollection } from '@/utils/displayHeuristics';
 
 describe('isRelational', () => {
   it('returns true when meta.special includes m2o, o2m, m2m, m2a, files, translations', () => {
@@ -44,5 +44,90 @@ describe('parseTemplateTokens', () => {
 
   it('deduplicates repeated tokens', () => {
     expect(parseTemplateTokens('{{name}} - {{name}}')).toEqual(['name']);
+  });
+});
+
+describe('resolveTargetCollection', () => {
+  function makeRelationsStore(relations: Record<string, any[]>) {
+    return {
+      getRelationsForField: (collection: string, fieldName: string) =>
+        relations[`${collection}.${fieldName}`] ?? [],
+    };
+  }
+  function makeFieldsStore(map: Record<string, any>) {
+    return {
+      getField: (collection: string | null, field: string) =>
+        collection ? map[`${collection}.${field}`] ?? null : null,
+    };
+  }
+
+  it('returns m2o target collection', () => {
+    const relations = makeRelationsStore({
+      'parent.author': [
+        { collection: 'parent', field: 'author', related_collection: 'directus_users' },
+      ],
+    });
+    const fields = makeFieldsStore({});
+    const field = { collection: 'parent', field: 'author', meta: { special: ['m2o'] } } as any;
+    expect(resolveTargetCollection(field, relations as any, fields as any)).toBe('directus_users');
+  });
+
+  it('returns target through the junction for m2m', () => {
+    const relations = makeRelationsStore({
+      'parent.tags': [
+        {
+          collection: 'parent_tags',
+          field: 'parent_id',
+          related_collection: 'parent',
+          meta: { junction_field: 'tag_id' },
+        },
+      ],
+    });
+    const fields = makeFieldsStore({
+      'parent_tags.tag_id': {
+        schema: { foreign_key_table: 'tags' },
+        meta: { special: ['m2o'] },
+      },
+    });
+    const field = { collection: 'parent', field: 'tags', meta: { special: ['m2m'] } } as any;
+    expect(resolveTargetCollection(field, relations as any, fields as any)).toBe('tags');
+  });
+
+  it('returns null when no relations are defined', () => {
+    const relations = makeRelationsStore({});
+    const fields = makeFieldsStore({});
+    const field = { collection: 'parent', field: 'unknown', meta: { special: ['m2o'] } } as any;
+    expect(resolveTargetCollection(field, relations as any, fields as any)).toBe(null);
+  });
+
+  it('returns null for a non-relational field', () => {
+    const relations = makeRelationsStore({});
+    const fields = makeFieldsStore({});
+    const field = { collection: 'parent', field: 'title', meta: { special: [] } } as any;
+    expect(resolveTargetCollection(field, relations as any, fields as any)).toBe(null);
+  });
+
+  it('does NOT junction-traverse for translation fields (special=translations)', () => {
+    // Translation relations also carry meta.junction_field (languages_code), but the
+    // intended target is the translations collection itself — not the languages table.
+    const relations = makeRelationsStore({
+      'parent.translations': [
+        {
+          collection: 'parent_translations',
+          field: 'parent_id',
+          related_collection: 'parent',
+          meta: { junction_field: 'languages_code' },
+        },
+      ],
+    });
+    const fields = makeFieldsStore({});
+    const field = {
+      collection: 'parent',
+      field: 'translations',
+      meta: { special: ['translations'] },
+    } as any;
+    expect(resolveTargetCollection(field, relations as any, fields as any)).toBe(
+      'parent_translations'
+    );
   });
 });

--- a/tests/unit/utils/fieldValidity.test.ts
+++ b/tests/unit/utils/fieldValidity.test.ts
@@ -4,6 +4,7 @@ import {
   isSortFieldValid,
   filterValidFields,
   filterValidSort,
+  filterValidColumnDisplays,
 } from '@/utils/fieldValidity';
 
 const COLLECTION = 'issue_47_test';
@@ -140,5 +141,54 @@ describe('filterValidSort', () => {
 
   it('returns [] when every entry references a deleted field', () => {
     expect(filterValidSort(['ghost_a', '-ghost_b'], COLLECTION, fieldsStore)).toEqual([]);
+  });
+});
+
+describe('filterValidColumnDisplays', () => {
+  let fieldsStore: ReturnType<typeof makeFieldsStore>;
+
+  beforeEach(() => {
+    fieldsStore = makeFieldsStore();
+  });
+
+  it('keeps entries whose root field still exists', () => {
+    const input = {
+      title: { template: '{{title}}' },
+      tags: { template: '{{name}}' },
+    };
+    expect(filterValidColumnDisplays(input, COLLECTION, fieldsStore)).toEqual({
+      title: { template: '{{title}}' },
+      tags: { template: '{{name}}' },
+    });
+  });
+
+  it('drops entries whose root field has been deleted', () => {
+    const input = {
+      title: { template: '{{title}}' },
+      ghost: { template: '{{name}}' },
+    };
+    expect(filterValidColumnDisplays(input, COLLECTION, fieldsStore)).toEqual({
+      title: { template: '{{title}}' },
+    });
+  });
+
+  it('keeps translation root entries (translations.title, no language suffix)', () => {
+    const input = {
+      'translations.title': { template: '📌 {{title}}' },
+    };
+    expect(filterValidColumnDisplays(input, COLLECTION, fieldsStore)).toEqual({
+      'translations.title': { template: '📌 {{title}}' },
+    });
+  });
+
+  it('returns {} for null/undefined/empty input', () => {
+    expect(filterValidColumnDisplays(null, COLLECTION, fieldsStore)).toEqual({});
+    expect(filterValidColumnDisplays(undefined, COLLECTION, fieldsStore)).toEqual({});
+    expect(filterValidColumnDisplays({}, COLLECTION, fieldsStore)).toEqual({});
+  });
+
+  it('returns {} when collection is null', () => {
+    const input = { title: { template: '{{title}}' } };
+    expect(filterValidColumnDisplays(input, null, fieldsStore)).toEqual({});
   });
 });


### PR DESCRIPTION
Closes #48

## Summary

Lets users customize how relational columns render in the layout itself, without changing global field settings. Three render paths in priority order:

1. **Layout override** — set per-bookmark in the new sidebar section "Column Displays". Stored in `layoutOptions.columnDisplays`.
2. **Field-settings display** — honored when set globally in Settings → Data Model.
3. **Smart heuristics** — fallback for relational fields that have neither: `name` / `title` / `label` for custom collections; `first_name + last_name` for `directus_users`; `title` / `filename_download` for `directus_files`. Means M2M and M2O columns no longer render as raw `[1, 2, 3]` IDs out of the box.

M2M traversal through the junction collection is automatic and transparent — users write `{{name}}`, the engine builds `field.junction_field.name` for the API request and unwraps junction items at render time.

## Architecture

Three layers added on top of existing extension code:

| Layer | Files |
|---|---|
| Pure utilities | `src/utils/displayHeuristics.ts` (new), `src/utils/fieldValidity.ts` (extended) |
| Composable | `src/composables/useColumnDisplays.ts` (new) |
| UI | `src/components/ColumnDisplaysSection.vue` + `ColumnDisplayItem.vue` + `ColumnDisplayEditor.vue` (new) |
| Wire-up | `index.ts`, `src/super-table.vue`, `src/options.vue`, `src/composables/useAliasFields.ts`, `src/components/EditableCellRelational.vue`, `src/utils/adjustFieldsForDisplays.ts` (extended) |

The editor uses Directus' built-in `interface-system-display-template` for the token editor — no custom template builder.

## Translations

Single override per root field (`translations.title`) applies to every language column derived from that field. The translations special-case short-circuits in `resolveTargetCollection` and `pickHeuristic` so the existing translation render path keeps working unchanged.

## Test plan

- [x] 96 unit tests across 6 test files (filterValidColumnDisplays, displayHeuristics 19 cases, useColumnDisplays 7 cases, adjustFieldsForDisplays override path)
- [x] E2E regression test `playwright-tools/test-issue-48.js` (gitignored dev-only) with 15 assertions covering both override and heuristic paths
- [x] Existing #47 regression test still passes (no regressions)
- [x] Manual smoke test on the live `issue_47_test` collection (M2M tags, M2O author, translations)
- [x] `pnpm run quality` (TypeScript strict, ESLint --max-warnings=0, Prettier) clean
- [x] `pnpm run build` clean

## What is intentionally NOT done

- Cross-field templating on plain columns (`{{title}} ({{slug}})` on the title column) — out of scope; documented in spec
- Per-language overrides — single override per root field covers 90% of use cases
- Confirmation dialog on delete — action is trivially revertable
- `useExtensions` canonical path — optional robustness improvement noted in spec for follow-up