### PR TITLE
Hotfix v0.3.2: Inline edit silently failing on non-id primary keys (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to the Super Layout Table Extension will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.1] - 2026-05-09
+## [0.3.2] - 2026-05-09
+
+### Fixed
+- **Inline editing silently failing for collections with non-`id` primary key
+  (Issue #44).** `handleUpdate` and `handleBooleanToggle` in
+  `EditableCellRelational.vue` were detecting the primary key by name pattern
+  matching (`key === 'id' || key.endsWith('_id')`), which produced no result on
+  collections whose primary key uses a different name (`code`, `slug`, `uuid`,
+  `sku`, …). Both functions now read the primary key field name from the
+  `primaryKeyField` computed property, which is sourced from the Directus
+  schema via the parent component. The previous heuristic could also have
+  selected an unrelated foreign-key column ending in `_id` and dispatched the
+  PATCH against the wrong record; that misdirection is no longer possible.
+
+
 
 ### Changed
 - Bumped 21 development dependencies to their latest patch versions within

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-super-table",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A powerful and feature-rich table layout extension for Directus 11+ with inline editing, quick filters, and manual sorting",
   "keywords": [
     "directus",

--- a/src/components/EditableCellRelational.vue
+++ b/src/components/EditableCellRelational.vue
@@ -610,13 +610,13 @@ function renderTemplate(value: any, template: string): string {
 }
 
 function handleUpdate(value: any) {
-  const primaryKey = Object.keys(props.item).find((key) => key === 'id' || key.endsWith('_id'));
+  const itemId = props.item?.[primaryKeyField.value];
 
-  if (primaryKey) {
+  if (itemId !== undefined && itemId !== null) {
     // Check if this is a full translations update
     if (typeof value === 'object' && value?.isFullTranslations) {
       // Handle full translations update from interface-translations
-      emit('update', props.item[primaryKey], 'translations', {
+      emit('update', itemId, 'translations', {
         isFullTranslations: true,
         translations: value.translations,
       });
@@ -631,17 +631,17 @@ function handleUpdate(value: any) {
         language: fieldLanguage.value, // Use language from field key or selected
         isTranslation: true,
       };
-      emit('update', props.item[primaryKey], props.fieldKey, translationUpdate);
+      emit('update', itemId, props.fieldKey, translationUpdate);
     } else {
-      emit('update', props.item[primaryKey], props.fieldKey, value);
+      emit('update', itemId, props.fieldKey, value);
     }
   }
 }
 
 function handleBooleanToggle(value: boolean) {
-  const primaryKey = Object.keys(props.item).find((key) => key === 'id' || key.endsWith('_id'));
-  if (primaryKey) {
-    emit('update', props.item[primaryKey], props.fieldKey, value);
+  const itemId = props.item?.[primaryKeyField.value];
+  if (itemId !== undefined && itemId !== null) {
+    emit('update', itemId, props.fieldKey, value);
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #44.

`handleUpdate` and `handleBooleanToggle` in `EditableCellRelational.vue` detected the primary key by name-pattern matching:

```js
const primaryKey = Object.keys(props.item).find((key) => key === 'id' || key.endsWith('_id'));
if (primaryKey) { emit('update', props.item[primaryKey], ...); }
```

When the primary key has a different name (`code`, `slug`, `uuid`, `sku`, …), the lookup returns `undefined`, the `if`-guard short-circuits, no event is emitted, and the inline edit silently never reaches the database — exactly the behaviour reported in #44.

The fix uses the `primaryKeyField` computed property that already exists in the same component. Its value is sourced from `useCollection().primaryKeyField` in the parent (`super-table.vue`) and passed in as `primary-key-field-name`, so it is always the schema-authoritative PK field name.

## Why the same pattern was a latent data-corruption risk

When an item carries both a real primary key (e.g. `code = "PROD-A1"`) and an unrelated field literally named `id` (or ending in `_id` like `parent_id`), the previous heuristic preferred those over the actual PK. The PATCH would then be dispatched against `\/items\/<collection>\/<id_value>` instead of `\/items\/<collection>\/<pk_value>` — at best a 404, at worst an update to an unrelated record. The new code reads the schema-authoritative PK name, so this misdirection is no longer possible.

## Verification

Reproduced the original bug, applied the fix, and re-tested manually against the running Directus instance:

| Scenario | Result |
|---|---|
| `code` PK + inline string edit | `PATCH /items/test_bug_44/ITEM-001` → 200, DB updated |
| `code` PK + direct boolean toggle | `PATCH /items/test_bug_44/ITEM-002` → 200, DB updated |
| `id` PK (regression) | `PATCH /items/test_bug_44_id/1` → 200, DB updated |
| `sku` PK with extra `id=999` and `parent_id=42` fields | `PATCH /items/test_bug_44_evil/PROD-A1` → 200, DB updated |

Quality checks pass (`pnpm run quality`):
- `vue-tsc --noEmit`
- `eslint . --max-warnings=0`
- `prettier --check`

## Test plan

- [x] Build the extension and load Directus
- [x] On a collection whose primary key is **not** `id` (e.g. `code`, `uuid`), switch to Super Table and enable inline editing
- [x] Edit a string field inline, click save → expect a `PATCH /items/<collection>/<pk-value>` and the value to persist
- [x] Enable Direct Boolean Toggle, click a boolean cell → expect the same `PATCH` flow
- [x] On any `id`-keyed collection, repeat both interactions → expect no regression