### PR TITLE
feat: permission-aware layout (issue #37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ live-test-*.png
 tags-vs-real-tags.png
 status-cell-debug.png
 current-page.png
+issue-37-*.png
+step*.png
+test*-*.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the Super Layout Table Extension will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.0 — Permission-aware layout (Issue #37)
+
+### Fixed
+- **Bug A:** Translation language columns the user cannot read are no longer rendered
+- **Bug B:** Inline-edit popover blocked on cells the user cannot update; tooltip explains
+- **Bug C:** `[object Object]` no longer leaks into translation cells when popover open
+- **Bug D:** Hauptcollection field permissions and translations field permissions handled consistently
+- **Bug E:** Filters referencing inaccessible fields are sanitized server-side; user notified
+- **Bug F:** Auto-resolved by Bug A — language code never leaks into header
+- **Bug G:** Bulk-action duplicate button hidden when user lacks create permission
+
+### Added
+- `usePermissions` composable as single source of truth for permission checks
+- `sanitizeFilter` utility for permission-aware filter trees
+- 403 errors during inline-save now surface as notifications instead of being swallowed
+
 ## [0.3.2] - 2026-05-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `combinedFilter` no longer mixes side-effects with computed evaluation; the user notification is now emitted from a dedicated watcher.
 - `PermissionAction` union no longer includes the unused `'share'` action.
 - `usePermissions` guards against array-shaped permission stores (legacy / future Directus shape changes) instead of silently failing.
+- `fieldsWithRelational` clarifies its behaviour: the primary key and translation language code path are added BEFORE the permission gate, and sanitize drops them only if the user lacks read permission. This mirrors native Directus's `useCollection.primaryKeyField`, which is itself permission-filtered, so users without PK read access see the same graceful degradation in both layouts (items render with limited interaction) instead of an empty 403 error state.
 
 ### Known limitations
 - Bulk-action **Edit / Delete / Add Item** buttons (rendered by Directus Core, not by this extension) remain visible-but-disabled when the user lacks the corresponding permission. A future Directus core PR is required to fully hide them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bug E:** Filters referencing inaccessible fields are sanitized server-side; user notified
 - **Bug F:** Auto-resolved by Bug A — language code never leaks into header
 - **Bug G:** Bulk-action duplicate button hidden when user lacks create permission
+- **L2 (post-audit):** Asymmetric permissions — when the `languages` collection is unrestricted but the translations junction has a row-level filter on `languages_code`, an aggregate-query probe now resolves the exact accessible languages (instead of `--` placeholder columns).
+- **L5 (post-audit):** File-browser drawer no longer renders empty when the user lacks read on `directus_files`. A clear warning notification fires instead.
 
 ### Added
 - `usePermissions` composable as single source of truth for permission checks
 - `sanitizeFilter` utility for permission-aware filter trees
+- `useTranslationLanguages` composable: probes the translations junction collection for accessible languages (covers row-level filters not exposed by `/permissions/me`)
 - 403 errors during inline-save now surface as notifications instead of being swallowed
+
+### Refactor
+- `combinedFilter` no longer mixes side-effects with computed evaluation; the user notification is now emitted from a dedicated watcher.
+- `PermissionAction` union no longer includes the unused `'share'` action.
+- `usePermissions` guards against array-shaped permission stores (legacy / future Directus shape changes) instead of silently failing.
+
+### Known limitations
+- Bulk-action **Edit / Delete / Add Item** buttons (rendered by Directus Core, not by this extension) remain visible-but-disabled when the user lacks the corresponding permission. A future Directus core PR is required to fully hide them.
 
 ## [0.3.2] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PermissionAction` union no longer includes the unused `'share'` action.
 - `usePermissions` guards against array-shaped permission stores (legacy / future Directus shape changes) instead of silently failing.
 - `fieldsWithRelational` clarifies its behaviour: the primary key and translation language code path are added BEFORE the permission gate, and sanitize drops them only if the user lacks read permission. This mirrors native Directus's `useCollection.primaryKeyField`, which is itself permission-filtered, so users without PK read access see the same graceful degradation in both layouts (items render with limited interaction) instead of an empty 403 error state.
+- `useTableApi.fetchItems` no longer requests `meta=filter_count,total_count` together with the items. The server resolves that meta block via `countDistinct(<pk>)` and would 403 for users without read on the primary key; the count is now fetched in parallel via `aggregate[count]=*` (`fetchItemCount`), which uses SQL `COUNT(*)` and works regardless of field-level permissions. Users without PK access can now use the layout instead of seeing an empty 403 state.
 
 ### Known limitations
 - Bulk-action **Edit / Delete / Add Item** buttons (rendered by Directus Core, not by this extension) remain visible-but-disabled when the user lacks the corresponding permission. A future Directus core PR is required to fully hide them.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-super-table",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "A powerful and feature-rich table layout extension for Directus 11+ with inline editing, quick filters, and manual sorting",
   "keywords": [
     "directus",

--- a/src/actions.vue
+++ b/src/actions.vue
@@ -2,9 +2,8 @@
   <div class="action-buttons">
     <!-- Duplicate Button nur anzeigen wenn Items ausgewählt sind -->
     <v-button
-      v-if="hasSelection"
+      v-if="hasSelection && canDuplicate"
       v-tooltip.bottom="duplicateTooltip"
-      :disabled="!canDuplicate"
       icon
       rounded
       secondary
@@ -97,6 +96,7 @@ import { computed, ref } from 'vue';
 import { useStores, useCollection } from '@directus/extensions-sdk';
 import { useI18n } from 'vue-i18n';
 import { useTableApi } from './composables/api';
+import { usePermissions } from './composables/usePermissions';
 
 // Props from layout state
 const props = defineProps<{
@@ -118,6 +118,7 @@ const { t } = useI18n();
 const tableApi = useTableApi();
 const { useNotificationsStore } = useStores();
 const notificationsStore = useNotificationsStore();
+const permissions = usePermissions();
 
 // State for Save Filter Dialog
 const saveDialogActive = ref(false);
@@ -191,12 +192,7 @@ const hasNativeFilter = computed(() => {
   return true;
 });
 
-// Als Admin haben wir immer Create-Rechte, außer es wird explizit verboten
-// In Layout Extensions ist der Permissions-Check anders als in anderen Extensions
-const canDuplicate = computed(() => {
-  // Einfacher Check - wenn wir hier sind, haben wir vermutlich Rechte
-  return true;
-});
+const canDuplicate = computed(() => permissions.canCreate(props.collection));
 
 const duplicateTooltip = computed(() => {
   const count = props.selection?.length || 0;

--- a/src/components/EditableCellRelational.vue
+++ b/src/components/EditableCellRelational.vue
@@ -418,11 +418,14 @@ const isFieldEditableComputed = computed(() => {
   if (!collection) return false;
 
   if (actualFieldKey.value.startsWith('translations.')) {
-    // Translation sub-field: check update on the translations junction collection
+    // Translation sub-field: resolve the junction collection and check update permission.
+    // `collection` may already be the junction (when called from a translation cell whose
+    // field metadata.collection points at the junction) or the parent collection. Try the
+    // parent → junction lookup first; fall back to treating `collection` as the junction.
     const subField = actualFieldKey.value.split('.').slice(1).join('.');
-    const transRelations = relationsStore.getRelationsForField(collection, 'translations');
-    const transCollection = transRelations?.[0]?.collection;
-    if (transCollection && !permissions.canUpdate(transCollection, subField)) return false;
+    const parentRels = relationsStore.getRelationsForField(collection, 'translations');
+    const transCollection = parentRels?.[0]?.collection || collection;
+    if (!permissions.canUpdate(transCollection, subField)) return false;
   } else {
     if (!permissions.canUpdate(collection, actualFieldKey.value)) return false;
   }
@@ -439,9 +442,9 @@ const permissionDenied = computed(() => {
 
   if (actualFieldKey.value.startsWith('translations.')) {
     const subField = actualFieldKey.value.split('.').slice(1).join('.');
-    const transCollection = relationsStore.getRelationsForField(collection, 'translations')?.[0]
-      ?.collection;
-    return transCollection ? !permissions.canUpdate(transCollection, subField) : false;
+    const parentRels = relationsStore.getRelationsForField(collection, 'translations');
+    const transCollection = parentRels?.[0]?.collection || collection;
+    return !permissions.canUpdate(transCollection, subField);
   }
   return !permissions.canUpdate(collection, actualFieldKey.value);
 });

--- a/src/components/EditableCellRelational.vue
+++ b/src/components/EditableCellRelational.vue
@@ -257,9 +257,9 @@ const displayValue = computed(() => {
     return props.edits;
   }
 
-  // Special handling for translations fields (issue #37 bug C)
-  // Delegated to a centralized helper to guard against translation-row objects
-  // leaking through and rendering as the literal "[object Object]".
+  // Translation sub-fields go through the centralised helper so a sibling
+  // re-render during a popover open cannot leak a whole translation row
+  // through as "[object Object]".
   if (actualFieldKey.value.includes('translations.')) {
     return resolveTranslationValue(
       props.item,
@@ -269,10 +269,8 @@ const displayValue = computed(() => {
     );
   }
 
-  // Handle relational fields with display templates.
-  // Resolved priority: override → field-display → heuristic → none.
-  // Issue #48: layout-level override (columnDisplays) takes priority over the
-  // field-settings display.
+  // Display-template resolution priority: column-display override →
+  // field's own display template → relational heuristic → none.
   const storageKey = props.fieldKey.includes(':') ? props.fieldKey.split(':')[0] : props.fieldKey;
   const override = props.columnDisplays?.[storageKey];
   const fieldTemplate =

--- a/src/components/EditableCellRelational.vue
+++ b/src/components/EditableCellRelational.vue
@@ -168,6 +168,7 @@ import ColorCell from './CellRenderers/ColorCell.vue';
 import TagCell from './TagCell.vue';
 import { isFieldEditable, getFieldEditWarning, getFieldSupportLevel } from '../utils/fieldSupport';
 import { pickHeuristic } from '../utils/displayHeuristics';
+import { resolveTranslationValue } from '../utils/resolveTranslationValue';
 import { usePermissions } from '../composables/usePermissions';
 
 const { useFieldsStore, useRelationsStore } = useStores();
@@ -256,33 +257,16 @@ const displayValue = computed(() => {
     return props.edits;
   }
 
-  // Special handling for translations fields
+  // Special handling for translations fields (issue #37 bug C)
+  // Delegated to a centralized helper to guard against translation-row objects
+  // leaking through and rendering as the literal "[object Object]".
   if (actualFieldKey.value.includes('translations.')) {
-    const translationField = actualFieldKey.value.split('.').slice(1).join('.');
-
-    // Check if translations exist and is an array
-    if (Array.isArray(props.item.translations) && props.item.translations.length > 0) {
-      // Use the language from field key (if specified) or the selected language
-      const targetLanguage = fieldLanguage.value;
-
-      if (targetLanguage) {
-        const languageField = props.languageCodeField || 'languages_code';
-        const translation = props.item.translations.find(
-          (t: any) => t[languageField] === targetLanguage
-        );
-
-        // Return the specific field value if translation exists
-        if (translation) {
-          return translation[translationField] || null;
-        }
-      }
-
-      // No translation for this language
-      return null;
-    }
-
-    // No translations available at all
-    return null;
+    return resolveTranslationValue(
+      props.item,
+      actualFieldKey.value,
+      fieldLanguage.value ?? null,
+      props.languageCodeField || 'languages_code'
+    );
   }
 
   // Handle relational fields with display templates.

--- a/src/components/EditableCellRelational.vue
+++ b/src/components/EditableCellRelational.vue
@@ -9,6 +9,7 @@
     :interface-type="'tags'"
     :interface-options="interfaceOptions"
     :is-editable="isFieldEditableComputed"
+    :permission-denied="permissionDenied"
     :is-relational="false"
     :auto-save="false"
     :saving="saving"
@@ -55,6 +56,7 @@
     :interface-type="getInterfaceType() || undefined"
     :interface-options="interfaceOptions"
     :is-editable="isFieldEditableComputed"
+    :permission-denied="permissionDenied"
     :is-relational="false"
     :auto-save="false"
     :language-code-field="props.languageCodeField"
@@ -166,10 +168,12 @@ import ColorCell from './CellRenderers/ColorCell.vue';
 import TagCell from './TagCell.vue';
 import { isFieldEditable, getFieldEditWarning, getFieldSupportLevel } from '../utils/fieldSupport';
 import { pickHeuristic } from '../utils/displayHeuristics';
+import { usePermissions } from '../composables/usePermissions';
 
 const { useFieldsStore, useRelationsStore } = useStores();
 const fieldsStore = useFieldsStore();
 const relationsStore = useRelationsStore();
+const permissions = usePermissions();
 
 const props = defineProps<{
   item: Item;
@@ -425,16 +429,37 @@ const resolvedDisplay = computed<ResolvedDisplay>(() => {
 const isFieldEditableComputed = computed(() => {
   if (!props.editMode) return false;
 
-  // Special case: translation fields should be editable if the base type is supported
+  // Permission check first — denies independent of field-support
+  const collection = props.field?.collection || props.item?.collection;
+  if (!collection) return false;
+
   if (actualFieldKey.value.startsWith('translations.')) {
-    // For now, allow editing of translation fields if edit mode is on
-    // The actual field support check will be done in the InlineEditPopover
-    return true;
+    // Translation sub-field: check update on the translations junction collection
+    const subField = actualFieldKey.value.split('.').slice(1).join('.');
+    const transRelations = relationsStore.getRelationsForField(collection, 'translations');
+    const transCollection = transRelations?.[0]?.collection;
+    if (transCollection && !permissions.canUpdate(transCollection, subField)) return false;
+  } else {
+    if (!permissions.canUpdate(collection, actualFieldKey.value)) return false;
   }
 
-  // Use the field support utility which already handles tags and other partial support fields
-  const editable = isFieldEditable(props.field, actualFieldKey.value);
-  return editable;
+  // Field-support check (unchanged)
+  if (actualFieldKey.value.startsWith('translations.')) return true;
+  return isFieldEditable(props.field, actualFieldKey.value);
+});
+
+const permissionDenied = computed(() => {
+  if (!props.editMode) return false;
+  const collection = props.field?.collection || props.item?.collection;
+  if (!collection) return false;
+
+  if (actualFieldKey.value.startsWith('translations.')) {
+    const subField = actualFieldKey.value.split('.').slice(1).join('.');
+    const transCollection = relationsStore.getRelationsForField(collection, 'translations')?.[0]
+      ?.collection;
+    return transCollection ? !permissions.canUpdate(transCollection, subField) : false;
+  }
+  return !permissions.canUpdate(collection, actualFieldKey.value);
 });
 
 // Get field edit warning message

--- a/src/components/InlineEditPopover.vue
+++ b/src/components/InlineEditPopover.vue
@@ -674,6 +674,19 @@ function handleCellClick(toggle: Function) {
 function formatDisplayValue(value: any): string {
   if (value === null || value === undefined) return '—';
 
+  // Defensive guard (issue #37 bug C): a translation-row object leaked through
+  // as the cell value (e.g. when sibling cells re-render while another cell's
+  // popover opens). Extract its `text` so we never render "[object Object]".
+  if (
+    value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    'text' in value &&
+    'languages_code' in value
+  ) {
+    return String((value as any).text ?? '—');
+  }
+
   // Handle hash/password fields - show dots instead of actual value
   if (
     props.fieldType === 'hash' ||

--- a/src/components/InlineEditPopover.vue
+++ b/src/components/InlineEditPopover.vue
@@ -427,6 +427,7 @@ interface Props {
   editModeActive?: boolean;
   fieldEditWarning?: string;
   languageCodeField?: string;
+  permissionDenied?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -631,12 +632,8 @@ watch(menuActive, (active) => {
 
 // Methods
 function getFieldTooltip() {
-  // Only show tooltip in edit mode for non-editable fields
-  if (!props.editModeActive) {
-    return undefined;
-  }
-
-  // Show warning for partially supported or unsupported fields
+  if (!props.editModeActive) return undefined;
+  if (props.permissionDenied) return 'You do not have permission to edit this field';
   if (
     props.fieldSupportLevel === 'partial' ||
     props.fieldSupportLevel === 'none' ||
@@ -644,16 +641,12 @@ function getFieldTooltip() {
   ) {
     return props.fieldEditWarning || 'This field has limited or no inline editing support';
   }
-
   return undefined;
 }
 
 function shouldShowIcon() {
-  // Only show lock icons when edit mode is active and field is not editable
-  if (!props.editModeActive) {
-    return false;
-  }
-  // Only show icon for non-editable fields (lock indicator)
+  if (!props.editModeActive) return false;
+  if (props.permissionDenied) return true;
   return (
     props.fieldSupportLevel === 'none' ||
     props.fieldSupportLevel === 'readonly' ||

--- a/src/components/InlineEditPopover.vue
+++ b/src/components/InlineEditPopover.vue
@@ -404,9 +404,15 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue';
+import { useStores } from '@directus/extensions-sdk';
 import { useTableApi } from '../composables/api';
+import { usePermissions } from '../composables/usePermissions';
 import TagEditor from './CellRenderers/TagEditor.vue';
 // Note: useDrawer might not be available in all versions, we'll use alternative approach
+
+const { useNotificationsStore } = useStores();
+const notificationsStore = useNotificationsStore();
+const permissions = usePermissions();
 
 interface Props {
   value: any;
@@ -581,9 +587,20 @@ watch(menuActive, (active) => {
       }
     }
 
-    // For file fields, open drawer immediately instead of popover
+    // For file fields, open drawer immediately instead of popover.
+    // Pre-check: the drawer needs read access to directus_files to render.
+    // Without it the drawer would appear empty / broken; surface a clear
+    // notification instead.
     if (isFileField.value) {
       menuActive.value = false; // Close the popover
+      if (!permissions.canRead('directus_files')) {
+        notificationsStore.add({
+          type: 'warning',
+          title: 'No file access',
+          text: "You don't have permission to browse files. Ask an admin to grant read access on directus_files.",
+        });
+        return;
+      }
       // Initialize values before opening file browser
       originalValue.value = props.value;
       localValue.value = props.value;

--- a/src/components/InlineEditPopover.vue
+++ b/src/components/InlineEditPopover.vue
@@ -691,9 +691,9 @@ function handleCellClick(toggle: Function) {
 function formatDisplayValue(value: any): string {
   if (value === null || value === undefined) return '—';
 
-  // Defensive guard (issue #37 bug C): a translation-row object leaked through
-  // as the cell value (e.g. when sibling cells re-render while another cell's
-  // popover opens). Extract its `text` so we never render "[object Object]".
+  // Defensive guard: a translation-row object can leak through as the cell
+  // value (e.g. when a sibling re-renders while another cell's popover opens).
+  // Extract `text` so we never render "[object Object]".
   if (
     value &&
     typeof value === 'object' &&

--- a/src/composables/api.ts
+++ b/src/composables/api.ts
@@ -31,58 +31,34 @@ export function useTableApi() {
   const filterCount = ref(0);
 
   /**
-   * Fetch items from the API
+   * Fetch items from the API.
+   *
+   * Intentionally does NOT request `meta=filter_count,total_count`. The
+   * server resolves that meta block via `countDistinct(pk)` which 403s for
+   * users without read permission on the primary key — see `fetchItemCount`
+   * below for the count, which uses `count(*)` and works regardless.
    */
   async function fetchItems(options: ApiOptions): Promise<ApiResponse> {
     loading.value = true;
     error.value = null;
 
     try {
-      // Build query parameters
       const params: any = {
         fields: options.fields,
         page: options.page || 1,
         limit: options.limit || 100,
-        meta: 'filter_count,total_count',
       };
+      if (options.filter) params.filter = options.filter;
+      if (options.search) params.search = options.search;
+      if (options.sort && options.sort.length > 0) params.sort = options.sort;
+      if (options.deep) params.deep = options.deep;
+      if (options.alias) params.alias = options.alias;
 
-      // Add filter if provided
-      if (options.filter) {
-        params.filter = options.filter;
-      }
-
-      // Add search if provided
-      if (options.search) {
-        params.search = options.search;
-      }
-
-      // Add sort if provided
-      if (options.sort && options.sort.length > 0) {
-        params.sort = options.sort;
-      }
-
-      // Add deep parameters for relations
-      if (options.deep) {
-        params.deep = options.deep;
-      }
-
-      // Add alias parameters
-      if (options.alias) {
-        params.alias = options.alias;
-      }
-
-      // Make API request
       const response = await api.get(`/items/${options.collection}`, { params });
 
       if (response.data) {
         items.value = response.data.data || [];
-        totalCount.value = response.data.meta?.total_count || 0;
-        filterCount.value = response.data.meta?.filter_count || 0;
-
-        return {
-          data: items.value,
-          meta: response.data.meta,
-        };
+        return { data: items.value };
       }
 
       return { data: [] };
@@ -91,6 +67,34 @@ export function useTableApi() {
       throw err;
     } finally {
       loading.value = false;
+    }
+  }
+
+  /**
+   * Fetch the filter-count for the current query as a separate request.
+   *
+   * Uses `aggregate[count]=*` (SQL `COUNT(*)`) so it does not require read
+   * permission on the primary key — `meta=filter_count` and
+   * `aggregate[countDistinct]=<pk>` both 403 when the user lacks PK access.
+   * Returns the previous count on failure so a transient aggregate error
+   * doesn't reset pagination to zero.
+   */
+  async function fetchItemCount(
+    collection: string,
+    filter?: Filter,
+    search?: string
+  ): Promise<number> {
+    try {
+      const params: any = { aggregate: { count: '*' } };
+      if (filter) params.filter = filter;
+      if (search) params.search = search;
+      const response = await api.get(`/items/${collection}`, { params });
+      const count = Number(response.data?.data?.[0]?.count ?? 0);
+      filterCount.value = count;
+      totalCount.value = count;
+      return count;
+    } catch {
+      return filterCount.value;
     }
   }
 
@@ -514,6 +518,7 @@ export function useTableApi() {
     totalCount: computed(() => totalCount.value),
     filterCount: computed(() => filterCount.value),
     fetchItems,
+    fetchItemCount,
     updateItem,
     updateTranslation,
     deleteItems,

--- a/src/composables/usePermissions.ts
+++ b/src/composables/usePermissions.ts
@@ -40,6 +40,10 @@ export function usePermissions() {
 
     if (!field) return true;
 
+    // `entry.fields` is the authoritative field-level whitelist. `access` is
+    // a coarser hint that Directus also reports as `'full'` for permissions
+    // whose `fields` is an explicit allow-list — so do NOT short-circuit on
+    // `access === 'full'` here, that would let denied fields through.
     const fields = entry.fields ?? [];
     if (fields.includes('*')) return true;
     return fields.includes(field);

--- a/src/composables/usePermissions.ts
+++ b/src/composables/usePermissions.ts
@@ -1,7 +1,7 @@
 import { useStores } from '@directus/extensions-sdk';
 import { unref } from 'vue';
 
-export type PermissionAction = 'read' | 'create' | 'update' | 'delete' | 'share';
+export type PermissionAction = 'read' | 'create' | 'update' | 'delete';
 export type PermissionAccess = 'full' | 'partial' | 'none';
 
 interface PermissionEntry {
@@ -20,14 +20,18 @@ interface PermissionsByCollection {
   };
 }
 
+function isPermissionsMap(value: unknown): value is PermissionsByCollection {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
 export function usePermissions() {
   const { usePermissionsStore } = useStores();
   const permissionsStore = usePermissionsStore();
 
   function getEntry(collection: string, action: PermissionAction): PermissionEntry | null {
-    const map = unref(permissionsStore.permissions) as PermissionsByCollection | undefined;
-    const perms = map?.[collection];
-    return perms?.[action] ?? null;
+    const raw = unref(permissionsStore.permissions);
+    if (!isPermissionsMap(raw)) return null;
+    return raw[collection]?.[action] ?? null;
   }
 
   function canAction(collection: string, action: PermissionAction, field?: string): boolean {

--- a/src/composables/usePermissions.ts
+++ b/src/composables/usePermissions.ts
@@ -9,6 +9,11 @@ interface PermissionEntry {
   fields?: string[];
 }
 
+interface SanitizeOptions {
+  translationsCollection?: string;
+  accessibleLanguages?: string[];
+}
+
 interface PermissionsByCollection {
   [collection: string]: {
     [action in PermissionAction]?: PermissionEntry;
@@ -43,11 +48,36 @@ export function usePermissions() {
       .map((lang) => lang.code);
   }
 
+  function sanitizeFields(
+    collection: string,
+    fields: string[],
+    options: SanitizeOptions = {}
+  ): string[] {
+    return fields.filter((rawKey) => {
+      const [pathPart, lang] = rawKey.includes(':') ? rawKey.split(':') : [rawKey, null];
+      const segments = pathPart.split('.');
+      const rootField = segments[0];
+
+      if (!canAction(collection, 'read', rootField)) return false;
+
+      if (rootField === 'translations' && segments.length > 1) {
+        const subField = segments.slice(1).join('.');
+        const transCol = options.translationsCollection;
+        if (transCol && !canAction(transCol, 'read', subField)) return false;
+        if (lang && options.accessibleLanguages && !options.accessibleLanguages.includes(lang))
+          return false;
+      }
+
+      return true;
+    });
+  }
+
   return {
     canRead: (collection: string, field?: string) => canAction(collection, 'read', field),
     canUpdate: (collection: string, field?: string) => canAction(collection, 'update', field),
     canCreate: (collection: string) => canAction(collection, 'create'),
     canDelete: (collection: string) => canAction(collection, 'delete'),
     getAccessibleLanguages,
+    sanitizeFields,
   };
 }

--- a/src/composables/usePermissions.ts
+++ b/src/composables/usePermissions.ts
@@ -1,0 +1,45 @@
+import { useStores } from '@directus/extensions-sdk';
+import { unref } from 'vue';
+
+export type PermissionAction = 'read' | 'create' | 'update' | 'delete' | 'share';
+export type PermissionAccess = 'full' | 'partial' | 'none';
+
+interface PermissionEntry {
+  access: PermissionAccess;
+  fields?: string[];
+}
+
+interface PermissionsByCollection {
+  [collection: string]: {
+    [action in PermissionAction]?: PermissionEntry;
+  };
+}
+
+export function usePermissions() {
+  const { usePermissionsStore } = useStores();
+  const permissionsStore = usePermissionsStore();
+
+  function getEntry(collection: string, action: PermissionAction): PermissionEntry | null {
+    const map = unref(permissionsStore.permissions) as PermissionsByCollection | undefined;
+    const perms = map?.[collection];
+    return perms?.[action] ?? null;
+  }
+
+  function canAction(collection: string, action: PermissionAction, field?: string): boolean {
+    const entry = getEntry(collection, action);
+    if (!entry || entry.access === 'none') return false;
+
+    if (!field) return true;
+
+    const fields = entry.fields ?? [];
+    if (fields.includes('*')) return true;
+    return fields.includes(field);
+  }
+
+  return {
+    canRead: (collection: string, field?: string) => canAction(collection, 'read', field),
+    canUpdate: (collection: string, field?: string) => canAction(collection, 'update', field),
+    canCreate: (collection: string) => canAction(collection, 'create'),
+    canDelete: (collection: string) => canAction(collection, 'delete'),
+  };
+}

--- a/src/composables/usePermissions.ts
+++ b/src/composables/usePermissions.ts
@@ -36,10 +36,18 @@ export function usePermissions() {
     return fields.includes(field);
   }
 
+  function getAccessibleLanguages(allLanguages: { code: string; name: string }[]): string[] {
+    if (!canAction('languages', 'read')) return [];
+    return allLanguages
+      .filter((lang) => canAction('languages', 'read', lang.code) || canAction('languages', 'read'))
+      .map((lang) => lang.code);
+  }
+
   return {
     canRead: (collection: string, field?: string) => canAction(collection, 'read', field),
     canUpdate: (collection: string, field?: string) => canAction(collection, 'update', field),
     canCreate: (collection: string) => canAction(collection, 'create'),
     canDelete: (collection: string) => canAction(collection, 'delete'),
+    getAccessibleLanguages,
   };
 }

--- a/src/composables/useTableEdits.ts
+++ b/src/composables/useTableEdits.ts
@@ -2,6 +2,7 @@ import { ref, computed, Ref } from 'vue';
 import type { Field } from '@directus/types';
 import type { Edits } from '../types/table.types';
 import { useTableApi } from './api';
+import { useStores } from '@directus/extensions-sdk';
 
 export function useTableEdits(
   collection: Ref<string>,
@@ -11,6 +12,8 @@ export function useTableEdits(
   languageCodeField = 'languages_code'
 ) {
   const tableApi = useTableApi();
+  const { useNotificationsStore } = useStores();
+  const notificationsStore = useNotificationsStore();
   const edits = ref<Edits>({});
   const hasEdits = computed(() => Object.keys(edits.value).length > 0);
   const savingCells = ref<Record<string, boolean>>({});
@@ -111,8 +114,13 @@ export function useTableEdits(
 
       // Refresh the item data
       await getItems();
-    } catch {
-      // Failed to save edits
+    } catch (error: any) {
+      const status = error?.response?.status ?? error?.status;
+      const message =
+        status === 403
+          ? 'You do not have permission to update this field'
+          : error?.message || 'Failed to save changes';
+      notificationsStore.add({ type: 'error', title: 'Save failed', text: message });
     } finally {
       // Clear saving state
       for (const field of Object.keys(changes)) {

--- a/src/composables/useTranslationLanguages.ts
+++ b/src/composables/useTranslationLanguages.ts
@@ -1,0 +1,70 @@
+import { onMounted, ref, watch, type Ref } from 'vue';
+import { useApi } from '@directus/extensions-sdk';
+
+/**
+ * Probes the user's accessible languages by querying which `languages_code`
+ * values appear in the translations junction collection. The server enforces
+ * the row-level filter automatically, so the result reflects exactly the
+ * languages the user can read — including row-level restrictions that the
+ * client cannot otherwise inspect (Directus does not expose raw permission
+ * filters via /permissions/me).
+ *
+ * Returns:
+ *   - non-empty `string[]` when the probe succeeded and the collection had
+ *     at least one accessible row,
+ *   - `null` when the probe failed (network error, 403, etc.) — caller is
+ *     expected to fall back to permission-based detection,
+ *   - `null` when the collection is empty (no rows exist at all) so callers
+ *     don't accidentally drop every language column on a fresh installation.
+ */
+export function useTranslationLanguages(
+  translationsCollection: Ref<string | null>,
+  languageCodeField: Ref<string>
+) {
+  const api = useApi();
+  const probedLanguages = ref<string[] | null>(null);
+  const probing = ref(false);
+
+  async function probe(): Promise<void> {
+    const collection = translationsCollection.value;
+    const codeField = languageCodeField.value;
+    if (!collection || !codeField) {
+      probedLanguages.value = null;
+      return;
+    }
+    probing.value = true;
+    try {
+      const response = await api.get(`/items/${collection}`, {
+        params: {
+          aggregate: { count: '*' },
+          groupBy: [codeField],
+          limit: -1,
+        },
+      });
+      const rows = (response?.data?.data ?? []) as Array<Record<string, unknown>>;
+      const codes = rows
+        .map((row) => row[codeField])
+        .filter((c): c is string => typeof c === 'string' && c.length > 0);
+      probedLanguages.value = codes.length > 0 ? codes : null;
+    } catch {
+      probedLanguages.value = null;
+    } finally {
+      probing.value = false;
+    }
+  }
+
+  // Re-probe on subsequent ref changes. Initial probe is deferred to onMounted
+  // so we don't force evaluation of upstream computeds (e.g. hasTranslationFields)
+  // before they are initialized in the parent setup() — a previous attempt with
+  // `{ immediate: true }` triggered a TDZ error.
+  watch([translationsCollection, languageCodeField], () => {
+    if (translationsCollection.value) probe();
+    else probedLanguages.value = null;
+  });
+
+  onMounted(() => {
+    if (translationsCollection.value) probe();
+  });
+
+  return { probedLanguages, probing, probe };
+}

--- a/src/composables/useTranslationLanguages.ts
+++ b/src/composables/useTranslationLanguages.ts
@@ -2,20 +2,12 @@ import { onMounted, ref, watch, type Ref } from 'vue';
 import { useApi } from '@directus/extensions-sdk';
 
 /**
- * Probes the user's accessible languages by querying which `languages_code`
- * values appear in the translations junction collection. The server enforces
- * the row-level filter automatically, so the result reflects exactly the
- * languages the user can read — including row-level restrictions that the
- * client cannot otherwise inspect (Directus does not expose raw permission
- * filters via /permissions/me).
- *
- * Returns:
- *   - non-empty `string[]` when the probe succeeded and the collection had
- *     at least one accessible row,
- *   - `null` when the probe failed (network error, 403, etc.) — caller is
- *     expected to fall back to permission-based detection,
- *   - `null` when the collection is empty (no rows exist at all) so callers
- *     don't accidentally drop every language column on a fresh installation.
+ * Probe the translations junction for the language codes the user can actually
+ * read. The server applies row-level permission filters during the aggregate,
+ * so the result captures restrictions Directus does not expose via
+ * `/permissions/me`. Returns `null` on failure or when the collection has no
+ * accessible rows — the caller is expected to fall back to a permission-store
+ * lookup so an empty collection doesn't silently drop every language column.
  */
 export function useTranslationLanguages(
   translationsCollection: Ref<string | null>,
@@ -23,7 +15,6 @@ export function useTranslationLanguages(
 ) {
   const api = useApi();
   const probedLanguages = ref<string[] | null>(null);
-  const probing = ref(false);
 
   async function probe(): Promise<void> {
     const collection = translationsCollection.value;
@@ -32,7 +23,6 @@ export function useTranslationLanguages(
       probedLanguages.value = null;
       return;
     }
-    probing.value = true;
     try {
       const response = await api.get(`/items/${collection}`, {
         params: {
@@ -48,15 +38,12 @@ export function useTranslationLanguages(
       probedLanguages.value = codes.length > 0 ? codes : null;
     } catch {
       probedLanguages.value = null;
-    } finally {
-      probing.value = false;
     }
   }
 
-  // Re-probe on subsequent ref changes. Initial probe is deferred to onMounted
-  // so we don't force evaluation of upstream computeds (e.g. hasTranslationFields)
-  // before they are initialized in the parent setup() — a previous attempt with
-  // `{ immediate: true }` triggered a TDZ error.
+  // The initial probe is deferred to onMounted so upstream computeds (e.g.
+  // `hasTranslationFields`) are initialized before the watcher's reactive
+  // tracking touches them — `{ immediate: true }` here triggers a TDZ error.
   watch([translationsCollection, languageCodeField], () => {
     if (translationsCollection.value) probe();
     else probedLanguages.value = null;
@@ -66,5 +53,5 @@ export function useTranslationLanguages(
     if (translationsCollection.value) probe();
   });
 
-  return { probedLanguages, probing, probe };
+  return { probedLanguages, probe };
 }

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -957,24 +957,30 @@ const totalPages = computed(() => {
   return Math.ceil(itemCount.value / limit.value);
 });
 
-// Fetch items function
+// Items + count are fetched as two separate requests so users without read
+// permission on the PK still see a populated table — `meta=filter_count`
+// resolves via `countDistinct(pk)` server-side and would 403, while
+// `aggregate[count]=*` (used by `fetchItemCount`) does not.
 async function getItems() {
   try {
-    const response = await tableApi.fetchItems({
-      collection: collection.value,
-      fields: fieldsWithRelational.value,
-      filter: combinedFilter.value,
-      sort: sort.value,
-      page: page.value,
-      limit: limit.value,
-      deep: deep.value,
-      alias: aliasQuery.value || undefined,
-    });
-
-    // Update our local items ref (not the one from tableApi)
-    items.value = response.data || [];
+    const [itemsResult] = await Promise.all([
+      tableApi.fetchItems({
+        collection: collection.value,
+        fields: fieldsWithRelational.value,
+        filter: combinedFilter.value,
+        sort: sort.value,
+        page: page.value,
+        limit: limit.value,
+        deep: deep.value,
+        alias: aliasQuery.value || undefined,
+      }),
+      tableApi
+        .fetchItemCount(collection.value, combinedFilter.value, searchQuery.value || undefined)
+        .catch(() => undefined),
+    ]);
+    items.value = itemsResult?.data || [];
   } catch {
-    // Error is handled by tableApi internally
+    // Items error already in tableApi.error; count is best-effort
   }
 }
 

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -1010,8 +1010,11 @@ watch(
   { immediate: true, deep: true }
 );
 
-// Combine all filters: presets + manual + search
-const combinedFilter = computed(() => {
+// Combine all filters: presets + manual + search, then sanitize against
+// the user's read permissions. Computed stays pure; the user-facing
+// notification is emitted from a watcher to keep side-effects out of
+// reactivity-sensitive computations.
+const sanitizedFilterResult = computed(() => {
   const presetFilter = presetMergedFilters.value;
   const searchFilterValue = searchFilter.value;
 
@@ -1021,23 +1024,27 @@ const combinedFilter = computed(() => {
 
   const merged =
     filters.length === 0 ? undefined : filters.length === 1 ? filters[0] : { _and: filters };
-  if (!merged) return undefined;
+  if (!merged) return { sanitized: undefined, removed: [] as string[] };
 
-  const { sanitized, removed } = sanitizeFilter(merged, (field: string) =>
-    permissions.canRead(collection.value, field)
-  );
-
-  if (removed.length > 0 && !filterSanitizationNotified.value) {
-    notificationsStore.add({
-      type: 'info',
-      title: 'Filter partially applied',
-      text: `Some filter conditions were removed because you don't have access: ${removed.join(', ')}`,
-    });
-    filterSanitizationNotified.value = true;
-  }
-
-  return (sanitized ?? undefined) as any;
+  return sanitizeFilter(merged, (field: string) => permissions.canRead(collection.value, field));
 });
+
+const combinedFilter = computed(() => (sanitizedFilterResult.value.sanitized ?? undefined) as any);
+
+watch(
+  () => sanitizedFilterResult.value.removed,
+  (removed) => {
+    if (removed.length > 0 && !filterSanitizationNotified.value) {
+      notificationsStore.add({
+        type: 'info',
+        title: 'Filter partially applied',
+        text: `Some filter conditions were removed because you don't have access: ${removed.join(', ')}`,
+      });
+      filterSanitizationNotified.value = true;
+    }
+  },
+  { immediate: true }
+);
 
 // Items & Loading with proper fields and alias handling
 // Data fetching with new API

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -379,18 +379,16 @@ const perPageOptions = PER_PAGE_OPTIONS;
 
 // Language items for v-select
 const languageItems = computed(() => {
-  // If no languages loaded yet, use fallback
-  if (!languages.value || languages.value.length === 0) {
-    return DEFAULT_LANGUAGES.map((lang) => ({
+  const baseList =
+    languages.value && languages.value.length > 0 ? languages.value : DEFAULT_LANGUAGES;
+  const accessibleLanguages = permissions.getAccessibleLanguages(baseList as any);
+
+  return baseList
+    .filter((lang) => accessibleLanguages.length === 0 || accessibleLanguages.includes(lang.code))
+    .map((lang) => ({
       text: lang.name,
       value: lang.code,
     }));
-  }
-
-  return languages.value.map((lang) => ({
-    text: lang.name,
-    value: lang.code,
-  }));
 });
 
 // Existing languages for the dialog (based on pending translation field)

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -388,12 +388,10 @@ const perPageOptions = PER_PAGE_OPTIONS;
 const permissions = usePermissions();
 const filterSanitizationNotified = ref(false);
 
-// Language items for v-select.
-// Uses the permission-store list (all languages the user can read in principle)
-// rather than the probe-based effectiveAccessibleLanguages — when adding columns
-// we want to offer every language the user could ever see, not just ones with
-// data right now. Column rendering itself still uses the stricter probe-based
-// list for tableHeaders/sanitizeFields.
+// "Add column" picker uses the permission-store list (every language the user
+// could ever see) rather than the probe-based `effectiveAccessibleLanguages`,
+// so empty languages still appear as options. Header rendering keeps the
+// stricter probe list.
 const languageItems = computed(() => {
   const baseList =
     languages.value && languages.value.length > 0 ? languages.value : DEFAULT_LANGUAGES;
@@ -449,8 +447,8 @@ const sortAllowed = computed(() => {
 // Use pagination composable
 const { page, limit } = useTablePagination(layoutQuery as any);
 
-// Use sort composable — pass collection + fieldsStore so stale sort fields
-// referencing deleted columns are silently dropped (issue #47).
+// Pass collection + fieldsStore so stale sort fields referencing deleted
+// columns are silently dropped instead of triggering 400s on the next fetch.
 const { sort, tableSort, onSortChange } = useTableSort(
   layoutQuery as any,
   collection as Ref<string | null>,
@@ -508,11 +506,9 @@ const { aliasedFields, aliasQuery, getFromAliasedItem } = useAliasFields(
   columnDisplaysRef
 );
 
-// Translation collection lookup (parent → junction). Used both for the
-// permission gate and for the row-level language probe below.
-// Declared AFTER `fields` is initialized because `hasTranslationFields`
-// reads `fields.value` and Vue's watcher in useTranslationLanguages tracks
-// dependencies eagerly during setup.
+// Must be declared after `fields` / `hasTranslationFields` so the watcher
+// inside `useTranslationLanguages` doesn't touch them before initialisation
+// (Vue tracks reactive dependencies eagerly during setup → TDZ otherwise).
 const translationsCollectionRef = computed<string | null>(() => {
   if (!hasTranslationFields.value) return null;
   return (
@@ -520,20 +516,14 @@ const translationsCollectionRef = computed<string | null>(() => {
   );
 });
 
-// Probe which languages the user can actually read from translations rows.
-// `languages` collection permission is just a proxy — when admins restrict
-// translations row-by-row (e.g. via `languages_code._in: [de-DE, en-GB]`),
-// the probe is the only way to know exact accessible languages.
+// Probe wins over the static permission-store lookup because Directus does
+// not expose row-level filters (e.g. `languages_code._in: [de-DE, en-GB]`)
+// via /permissions/me — the aggregate query is the only way to discover them.
 const { probedLanguages } = useTranslationLanguages(
   translationsCollectionRef,
   computed(() => translationConfig.value.languageCodeField)
 );
 
-// Effective list of accessible languages.
-//   1. Probe result, when available — most accurate (covers row-level filter).
-//   2. Permission-store `getAccessibleLanguages` fallback when probe returned
-//      null (collection empty, probe failed, no translations).
-//   3. Empty array when neither source has data (defense in depth: no filter).
 const effectiveAccessibleLanguages = computed<string[]>(() => {
   if (probedLanguages.value && probedLanguages.value.length > 0) {
     return probedLanguages.value;
@@ -550,22 +540,21 @@ const fieldsWithRelational = computed(() => {
     return aliasInfo.fields || [aliasInfo.key];
   });
 
-  // Remove duplicates
   const adjustedFields = [...new Set(allDisplayFields)];
 
-  // CRITICAL: Always include the primary key field for navigation and identification
+  // PK + language-code path are added BEFORE the permission gate so sanitize
+  // can drop them when the user lacks read access — matches native Directus,
+  // where `useCollection.primaryKeyField` is permission-filtered and a denied
+  // PK simply degrades interaction (no item-key, no inline edit) rather than
+  // 403'ing the entire fetch.
   const pkField = getPrimaryKeyFieldName();
-  if (!adjustedFields.includes(pkField)) {
-    adjustedFields.unshift(pkField); // Add at the beginning
+  if (!adjustedFields.includes(pkField)) adjustedFields.unshift(pkField);
+
+  if (hasTranslationFields.value) {
+    const languageFieldPath = getTranslationLanguageFieldPath(translationConfig.value);
+    if (!adjustedFields.includes(languageFieldPath)) adjustedFields.push(languageFieldPath);
   }
 
-  // Ensure language code field is included for translations
-  const languageFieldPath = getTranslationLanguageFieldPath(translationConfig.value);
-  if (hasTranslationFields.value && !adjustedFields.includes(languageFieldPath)) {
-    adjustedFields.push(languageFieldPath);
-  }
-
-  // Permission gate: drop fields/language-suffixed entries the user cannot read
   const translationsCollection = relationsStore.getRelationsForField(
     props.collection,
     'translations'
@@ -921,13 +910,11 @@ const sanitizedFilterResult = computed(() => {
     filters.length === 0 ? undefined : filters.length === 1 ? filters[0] : { _and: filters };
   if (!merged) return { sanitized: undefined, removed: [] as string[] };
 
-  // Permission check is scope-aware: when the walker descends into the
-  // translations junction (via `_some`/`_none`/`_every`), `scope` will be
-  // the junction collection name and we check sub-field permissions there
-  // instead of on the parent collection. Without this, a filter like
-  // `{ translations: { _some: { description: ... } } }` would slip past
-  // the parent `canRead('translations')` check and hit the server with a
-  // sub-field the user can't read — re-opening Bug E for nested filters.
+  // `nestedScopes` makes the walker check sub-fields under `_some`/`_none`/
+  // `_every` against the junction collection rather than the parent —
+  // without it, `{ translations: { _some: { description: ... } } }` would
+  // slip past the parent's `canRead('translations')` check and reach the
+  // server with a sub-field the user cannot read.
   const nestedScopes: Record<string, string | undefined> = {
     translations: translationsCollectionRef.value ?? undefined,
   };

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -921,7 +921,21 @@ const sanitizedFilterResult = computed(() => {
     filters.length === 0 ? undefined : filters.length === 1 ? filters[0] : { _and: filters };
   if (!merged) return { sanitized: undefined, removed: [] as string[] };
 
-  return sanitizeFilter(merged, (field: string) => permissions.canRead(collection.value, field));
+  // Permission check is scope-aware: when the walker descends into the
+  // translations junction (via `_some`/`_none`/`_every`), `scope` will be
+  // the junction collection name and we check sub-field permissions there
+  // instead of on the parent collection. Without this, a filter like
+  // `{ translations: { _some: { description: ... } } }` would slip past
+  // the parent `canRead('translations')` check and hit the server with a
+  // sub-field the user can't read — re-opening Bug E for nested filters.
+  const nestedScopes: Record<string, string | undefined> = {
+    translations: translationsCollectionRef.value ?? undefined,
+  };
+  return sanitizeFilter(
+    merged,
+    (field, scope) => permissions.canRead(scope ?? collection.value, field),
+    { nestedScopes }
+  );
 });
 
 const combinedFilter = computed(() => (sanitizedFilterResult.value.sanitized ?? undefined) as any);

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -380,6 +380,14 @@ const { languages, fetchLanguages } = useLanguageSelector();
 // Per page options for pagination
 const perPageOptions = PER_PAGE_OPTIONS;
 
+// Permissions composable + one-shot notification flag for sanitized filters.
+// Declared here (before any computed that references it) to avoid TDZ hazards
+// — Vue's reactive watchers track dependency reads eagerly during setup, and
+// any future watcher that touches the language picker would otherwise hit the
+// uninitialised binding.
+const permissions = usePermissions();
+const filterSanitizationNotified = ref(false);
+
 // Language items for v-select.
 // Uses the permission-store list (all languages the user can read in principle)
 // rather than the probe-based effectiveAccessibleLanguages — when adding columns
@@ -416,10 +424,6 @@ const hasTranslationFields = computed(() => {
 
 // Translation configuration
 const translationConfig = useTranslationConfig(layoutOptions);
-
-// Permissions composable + one-shot notification flag for sanitized filters
-const permissions = usePermissions();
-const filterSanitizationNotified = ref(false);
 
 // Layout Options
 const showToolbar = computed(() => layoutOptions.value?.showToolbar !== false);

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -289,10 +289,12 @@ import { useTableEdits } from './composables/useTableEdits';
 import { useTablePagination } from './composables/useTablePagination';
 import { useTableFields } from './composables/useTableFields';
 import { useFilterPresets } from './composables/useFilterPresets';
+import { usePermissions } from './composables/usePermissions';
 import {
   useTranslationConfig,
   getTranslationLanguageFieldPath,
 } from './composables/useTranslationConfig';
+import { sanitizeFilter } from './utils/sanitizeFilter';
 import { PER_PAGE_OPTIONS } from './constants/pagination';
 import { DEFAULT_LANGUAGES } from './constants/languages';
 import EditableCellRelational from './components/EditableCellRelational.vue';
@@ -408,6 +410,10 @@ const hasTranslationFields = computed(() => {
 
 // Translation configuration
 const translationConfig = useTranslationConfig(layoutOptions);
+
+// Permissions composable + one-shot notification flag for sanitized filters
+const permissions = usePermissions();
+const filterSanitizationNotified = ref(false);
 
 // Layout Options
 const showToolbar = computed(() => layoutOptions.value?.showToolbar !== false);
@@ -981,18 +987,28 @@ const combinedFilter = computed(() => {
   const presetFilter = presetMergedFilters.value;
   const searchFilterValue = searchFilter.value;
 
-  const filters = [];
-
+  const filters: any[] = [];
   if (presetFilter) filters.push(presetFilter);
   if (searchFilterValue) filters.push(searchFilterValue);
 
-  if (filters.length === 0) return undefined;
-  if (filters.length === 1) return filters[0];
+  const merged =
+    filters.length === 0 ? undefined : filters.length === 1 ? filters[0] : { _and: filters };
+  if (!merged) return undefined;
 
-  // Combine all filters with AND logic
-  return {
-    _and: filters,
-  };
+  const { sanitized, removed } = sanitizeFilter(merged, (field: string) =>
+    permissions.canRead(collection.value, field)
+  );
+
+  if (removed.length > 0 && !filterSanitizationNotified.value) {
+    notificationsStore.add({
+      type: 'info',
+      title: 'Filter partially applied',
+      text: `Some filter conditions were removed because you don't have access: ${removed.join(', ')}`,
+    });
+    filterSanitizationNotified.value = true;
+  }
+
+  return (sanitized ?? undefined) as any;
 });
 
 // Items & Loading with proper fields and alias handling

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -571,7 +571,29 @@ function getTranslationFieldMetadata(fieldKey: string) {
 }
 
 const tableHeaders = computed(() => {
+  const accessibleLanguages = permissions.getAccessibleLanguages(languages.value);
+  const translationsCollection = relationsStore.getRelationsForField(
+    collection.value,
+    'translations'
+  )?.[0]?.collection;
+
   const activeFields = fields.value
+    .filter((rawKey: string) => {
+      // Permission gate: drop language-suffixed translation fields the user can't read
+      if (rawKey.includes(':')) {
+        const [path, lang] = rawKey.split(':');
+        if (path.startsWith('translations.')) {
+          if (accessibleLanguages.length > 0 && !accessibleLanguages.includes(lang)) return false;
+          const subField = path.split('.').slice(1).join('.');
+          if (translationsCollection && !permissions.canRead(translationsCollection, subField))
+            return false;
+        }
+      }
+      // Permission gate: drop main-collection fields the user can't read
+      const rootField = rawKey.split(':')[0].split('.')[0];
+      if (!permissions.canRead(collection.value, rootField)) return false;
+      return true;
+    })
     .map((key: string) => {
       // Check if field has language suffix (e.g., "translations.description:de-DE")
       let actualFieldKey = key;

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -290,6 +290,7 @@ import { useTablePagination } from './composables/useTablePagination';
 import { useTableFields } from './composables/useTableFields';
 import { useFilterPresets } from './composables/useFilterPresets';
 import { usePermissions } from './composables/usePermissions';
+import { useTranslationLanguages } from './composables/useTranslationLanguages';
 import {
   useTranslationConfig,
   getTranslationLanguageFieldPath,
@@ -377,7 +378,12 @@ const { languages, fetchLanguages } = useLanguageSelector();
 // Per page options for pagination
 const perPageOptions = PER_PAGE_OPTIONS;
 
-// Language items for v-select
+// Language items for v-select.
+// Uses the permission-store list (all languages the user can read in principle)
+// rather than the probe-based effectiveAccessibleLanguages — when adding columns
+// we want to offer every language the user could ever see, not just ones with
+// data right now. Column rendering itself still uses the stricter probe-based
+// list for tableHeaders/sanitizeFields.
 const languageItems = computed(() => {
   const baseList =
     languages.value && languages.value.length > 0 ? languages.value : DEFAULT_LANGUAGES;
@@ -496,6 +502,39 @@ const { aliasedFields, aliasQuery, getFromAliasedItem } = useAliasFields(
   columnDisplaysRef
 );
 
+// Translation collection lookup (parent → junction). Used both for the
+// permission gate and for the row-level language probe below.
+// Declared AFTER `fields` is initialized because `hasTranslationFields`
+// reads `fields.value` and Vue's watcher in useTranslationLanguages tracks
+// dependencies eagerly during setup.
+const translationsCollectionRef = computed<string | null>(() => {
+  if (!hasTranslationFields.value) return null;
+  return (
+    relationsStore.getRelationsForField(collection.value, 'translations')?.[0]?.collection ?? null
+  );
+});
+
+// Probe which languages the user can actually read from translations rows.
+// `languages` collection permission is just a proxy — when admins restrict
+// translations row-by-row (e.g. via `languages_code._in: [de-DE, en-GB]`),
+// the probe is the only way to know exact accessible languages.
+const { probedLanguages } = useTranslationLanguages(
+  translationsCollectionRef,
+  computed(() => translationConfig.value.languageCodeField)
+);
+
+// Effective list of accessible languages.
+//   1. Probe result, when available — most accurate (covers row-level filter).
+//   2. Permission-store `getAccessibleLanguages` fallback when probe returned
+//      null (collection empty, probe failed, no translations).
+//   3. Empty array when neither source has data (defense in depth: no filter).
+const effectiveAccessibleLanguages = computed<string[]>(() => {
+  if (probedLanguages.value && probedLanguages.value.length > 0) {
+    return probedLanguages.value;
+  }
+  return permissions.getAccessibleLanguages(languages.value);
+});
+
 // Create fields for API query using the aliased fields (following original Directus pattern)
 const fieldsWithRelational = computed(() => {
   if (!props.collection) return [];
@@ -527,7 +566,7 @@ const fieldsWithRelational = computed(() => {
   )?.[0]?.collection;
   return permissions.sanitizeFields(props.collection, adjustedFields, {
     translationsCollection,
-    accessibleLanguages: permissions.getAccessibleLanguages(languages.value),
+    accessibleLanguages: effectiveAccessibleLanguages.value,
   });
 });
 
@@ -569,11 +608,8 @@ function getTranslationFieldMetadata(fieldKey: string) {
 }
 
 const tableHeaders = computed(() => {
-  const accessibleLanguages = permissions.getAccessibleLanguages(languages.value);
-  const translationsCollection = relationsStore.getRelationsForField(
-    collection.value,
-    'translations'
-  )?.[0]?.collection;
+  const accessibleLanguages = effectiveAccessibleLanguages.value;
+  const translationsCollection = translationsCollectionRef.value;
 
   const activeFields = fields.value
     .filter((rawKey: string) => {

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -45,7 +45,7 @@
     </div>
     <!-- Main Table -->
     <v-table
-      v-if="loading || (itemCount && itemCount > 0 && !error)"
+      v-if="loading || ((itemCount > 0 || items.length > 0) && !error)"
       ref="tableRef"
       v-model="selectionWritable"
       v-model:headers="tableHeadersWritable"
@@ -231,7 +231,7 @@
     </div>
 
     <!-- Pagination Footer -->
-    <div class="footer" v-if="itemCount && itemCount > 0">
+    <div class="footer" v-if="itemCount > 0 || items.length > 0">
       <div class="pagination">
         <v-pagination
           v-if="totalPages > 1"

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -522,7 +522,15 @@ const fieldsWithRelational = computed(() => {
     adjustedFields.push(languageFieldPath);
   }
 
-  return adjustedFields;
+  // Permission gate: drop fields/language-suffixed entries the user cannot read
+  const translationsCollection = relationsStore.getRelationsForField(
+    props.collection,
+    'translations'
+  )?.[0]?.collection;
+  return permissions.sanitizeFields(props.collection, adjustedFields, {
+    translationsCollection,
+    accessibleLanguages: permissions.getAccessibleLanguages(languages.value),
+  });
 });
 
 // Table headers with relational field support

--- a/src/utils/resolveTranslationValue.ts
+++ b/src/utils/resolveTranslationValue.ts
@@ -1,0 +1,33 @@
+/**
+ * Safely resolve a translation field value from an item's translations array.
+ *
+ * Issue #37 (Bug C): When the popover opens for one cell, sibling translation
+ * cells could re-render with the full translation row object as their value,
+ * which then renders as the literal string "[object Object]" through Vue's
+ * default `String()` coercion.
+ *
+ * This helper centralizes the lookup and guards against the edge case where
+ * the resolved sub-field value is itself an object that contains a `text`
+ * property (e.g. accidentally double-nested translation rows).
+ *
+ * @param item - Parent item carrying the `translations` array
+ * @param fieldPath - Field key including the leading `translations.` segment (e.g. `translations.text`)
+ * @param language - Target language code (e.g. `en-GB`); when null, no lookup is attempted
+ * @param languageCodeField - Field on each translation row holding the language code
+ * @returns The primitive translation value, or null when no translation matches
+ */
+export function resolveTranslationValue(
+  item: any,
+  fieldPath: string,
+  language: string | null,
+  languageCodeField: string
+): unknown {
+  if (!Array.isArray(item?.translations) || item.translations.length === 0) return null;
+  if (!language) return null;
+  const translation = item.translations.find((t: any) => t[languageCodeField] === language);
+  if (!translation) return null;
+  const subField = fieldPath.split('.').slice(1).join('.');
+  const value = translation[subField];
+  if (value && typeof value === 'object' && 'text' in value) return (value as any).text;
+  return value ?? null;
+}

--- a/src/utils/resolveTranslationValue.ts
+++ b/src/utils/resolveTranslationValue.ts
@@ -1,20 +1,9 @@
 /**
- * Safely resolve a translation field value from an item's translations array.
- *
- * Issue #37 (Bug C): When the popover opens for one cell, sibling translation
- * cells could re-render with the full translation row object as their value,
- * which then renders as the literal string "[object Object]" through Vue's
- * default `String()` coercion.
- *
- * This helper centralizes the lookup and guards against the edge case where
- * the resolved sub-field value is itself an object that contains a `text`
- * property (e.g. accidentally double-nested translation rows).
- *
- * @param item - Parent item carrying the `translations` array
- * @param fieldPath - Field key including the leading `translations.` segment (e.g. `translations.text`)
- * @param language - Target language code (e.g. `en-GB`); when null, no lookup is attempted
- * @param languageCodeField - Field on each translation row holding the language code
- * @returns The primitive translation value, or null when no translation matches
+ * Resolve a single translation field value (e.g. `translations.text` for a
+ * given language). Centralised so a sibling cell re-rendering during a popover
+ * open cannot leak the whole translation row through Vue's `String()`
+ * coercion as `"[object Object]"` — the final guard unwraps the row when it
+ * accidentally arrives in place of the sub-field value.
  */
 export function resolveTranslationValue(
   item: any,

--- a/src/utils/sanitizeFilter.ts
+++ b/src/utils/sanitizeFilter.ts
@@ -5,40 +5,106 @@ export interface SanitizeResult {
   removed: string[];
 }
 
-const LOGICAL_KEYS = new Set(['_and', '_or']);
+export interface SanitizeFilterOptions {
+  /**
+   * Map from a parent-field name to the collection it nests into.
+   * When the walker traverses into the value of a field listed here,
+   * inner field names will be checked against the nested collection's
+   * permissions instead of the outer scope.
+   *
+   * Example: `{ translations: 'pages_translations' }`
+   *  - Top-level `translations` is checked against the parent collection.
+   *  - Sub-fields inside relation match operators (`_some`, `_none`, `_every`)
+   *    are checked against `pages_translations`.
+   */
+  nestedScopes?: Record<string, string | undefined>;
+}
 
+const LOGICAL_KEYS = new Set(['_and', '_or']);
+const RELATION_MATCH_OPS = new Set(['_some', '_none', '_every']);
+
+/**
+ * Walk a Directus filter tree and remove conditions that reference fields
+ * the caller can't read. Logical operators (`_and`, `_or`) collapse if all
+ * their branches are dropped. Relation match operators (`_some`, `_none`,
+ * `_every`) recurse into a nested scope when configured via `nestedScopes`,
+ * so e.g. `{ translations: { _some: { description: ... } } }` is checked
+ * both at the parent level (translations field readable?) and at the
+ * junction collection level (description field readable?).
+ *
+ * The `canRead` callback receives `(field, scope?)`. When `scope` is
+ * undefined, the caller should check against the outer/parent collection.
+ * When `scope` is set (matches a value from `nestedScopes`), the caller
+ * should check against that collection.
+ */
 export function sanitizeFilter(
   filter: FilterValue,
-  canRead: (field: string) => boolean
+  canRead: (field: string, scope?: string) => boolean,
+  options: SanitizeFilterOptions = {}
 ): SanitizeResult {
   const removed: string[] = [];
+  const nestedScopes = options.nestedScopes ?? {};
 
-  function walk(node: FilterValue): FilterValue {
+  function isEmpty(node: FilterValue): boolean {
+    if (node === null || node === undefined) return true;
+    if (Array.isArray(node)) return node.length === 0;
+    if (typeof node === 'object') return Object.keys(node).length === 0;
+    return false;
+  }
+
+  function walk(node: FilterValue, scope?: string): FilterValue {
     if (node === null || node === undefined || typeof node !== 'object') return node;
 
     if (Array.isArray(node)) {
-      const cleaned = node
-        .map((entry) => walk(entry as FilterValue))
-        .filter((entry) => {
-          if (entry === null) return false;
-          if (typeof entry === 'object' && !Array.isArray(entry) && Object.keys(entry).length === 0)
-            return false;
-          return true;
-        });
-      return cleaned;
+      return node
+        .map((entry) => walk(entry as FilterValue, scope))
+        .filter((entry) => !isEmpty(entry as FilterValue));
     }
 
     const out: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(node)) {
+      // Logical: `_and` / `_or` — recurse into the array, same scope.
       if (LOGICAL_KEYS.has(key)) {
-        const cleaned = walk(value as FilterValue);
+        const cleaned = walk(value as FilterValue, scope);
         if (Array.isArray(cleaned) && cleaned.length > 0) out[key] = cleaned;
         continue;
       }
 
+      // Relation match: `_some` / `_none` / `_every` — recurse into the
+      // single inner filter object, same scope (we are already inside the
+      // relation; the parent established the scope before calling us).
+      if (RELATION_MATCH_OPS.has(key)) {
+        const cleaned = walk(value as FilterValue, scope);
+        if (!isEmpty(cleaned)) out[key] = cleaned;
+        continue;
+      }
+
+      // Other operators (`_eq`, `_icontains`, etc.) — leaf, passthrough.
+      if (key.startsWith('_')) {
+        out[key] = value;
+        continue;
+      }
+
+      // Field name — check permission at the current scope.
       const rootField = key.split('.')[0];
-      if (!canRead(rootField)) {
+      if (!canRead(rootField, scope)) {
         removed.push(key);
+        continue;
+      }
+
+      // Field is allowed at this scope. Does traversing into its value
+      // open a nested scope (e.g. translations → pages_translations)?
+      const nestedScope = nestedScopes[rootField];
+      if (nestedScope && value && typeof value === 'object' && !Array.isArray(value)) {
+        const cleanedInner = walk(value as FilterValue, nestedScope);
+        if (!isEmpty(cleanedInner)) {
+          out[key] = cleanedInner;
+        }
+        // If the inner walk dropped everything, the parent's clause is
+        // implicitly removed too. We do NOT push the parent to `removed[]`
+        // because the parent itself was permitted — the user-visible
+        // "removed fields" list contains the actual sub-fields that lost
+        // access (already pushed by the inner walk).
         continue;
       }
 

--- a/src/utils/sanitizeFilter.ts
+++ b/src/utils/sanitizeFilter.ts
@@ -7,15 +7,10 @@ export interface SanitizeResult {
 
 export interface SanitizeFilterOptions {
   /**
-   * Map from a parent-field name to the collection it nests into.
-   * When the walker traverses into the value of a field listed here,
-   * inner field names will be checked against the nested collection's
-   * permissions instead of the outer scope.
-   *
-   * Example: `{ translations: 'pages_translations' }`
-   *  - Top-level `translations` is checked against the parent collection.
-   *  - Sub-fields inside relation match operators (`_some`, `_none`, `_every`)
-   *    are checked against `pages_translations`.
+   * Maps a parent-field name (e.g. `translations`) to the collection its
+   * sub-fields live in (e.g. `pages_translations`). When the walker descends
+   * into a `_some`/`_none`/`_every` value under that field, sub-fields are
+   * checked against the nested collection instead of the outer scope.
    */
   nestedScopes?: Record<string, string | undefined>;
 }
@@ -24,18 +19,13 @@ const LOGICAL_KEYS = new Set(['_and', '_or']);
 const RELATION_MATCH_OPS = new Set(['_some', '_none', '_every']);
 
 /**
- * Walk a Directus filter tree and remove conditions that reference fields
- * the caller can't read. Logical operators (`_and`, `_or`) collapse if all
- * their branches are dropped. Relation match operators (`_some`, `_none`,
- * `_every`) recurse into a nested scope when configured via `nestedScopes`,
- * so e.g. `{ translations: { _some: { description: ... } } }` is checked
- * both at the parent level (translations field readable?) and at the
- * junction collection level (description field readable?).
- *
- * The `canRead` callback receives `(field, scope?)`. When `scope` is
- * undefined, the caller should check against the outer/parent collection.
- * When `scope` is set (matches a value from `nestedScopes`), the caller
- * should check against that collection.
+ * Walk a Directus filter tree and remove conditions on fields the caller
+ * cannot read. `_and`/`_or` branches collapse when emptied. Relation match
+ * operators (`_some`/`_none`/`_every`) descend into the configured nested
+ * scope so e.g. `{ translations: { _some: { description: ... } } }` is
+ * checked at both the parent level (`translations` readable?) and the
+ * junction-collection level (`description` readable?). The `canRead`
+ * callback receives the current `scope` (undefined = parent collection).
  */
 export function sanitizeFilter(
   filter: FilterValue,

--- a/src/utils/sanitizeFilter.ts
+++ b/src/utils/sanitizeFilter.ts
@@ -1,0 +1,52 @@
+type FilterValue = Record<string, unknown> | unknown[] | null;
+
+export interface SanitizeResult {
+  sanitized: FilterValue;
+  removed: string[];
+}
+
+const LOGICAL_KEYS = new Set(['_and', '_or']);
+
+export function sanitizeFilter(
+  filter: FilterValue,
+  canRead: (field: string) => boolean
+): SanitizeResult {
+  const removed: string[] = [];
+
+  function walk(node: FilterValue): FilterValue {
+    if (node === null || node === undefined || typeof node !== 'object') return node;
+
+    if (Array.isArray(node)) {
+      const cleaned = node
+        .map((entry) => walk(entry as FilterValue))
+        .filter((entry) => {
+          if (entry === null) return false;
+          if (typeof entry === 'object' && !Array.isArray(entry) && Object.keys(entry).length === 0)
+            return false;
+          return true;
+        });
+      return cleaned;
+    }
+
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(node)) {
+      if (LOGICAL_KEYS.has(key)) {
+        const cleaned = walk(value as FilterValue);
+        if (Array.isArray(cleaned) && cleaned.length > 0) out[key] = cleaned;
+        continue;
+      }
+
+      const rootField = key.split('.')[0];
+      if (!canRead(rootField)) {
+        removed.push(key);
+        continue;
+      }
+
+      out[key] = value;
+    }
+
+    return Object.keys(out).length === 0 ? null : out;
+  }
+
+  return { sanitized: walk(filter), removed };
+}

--- a/tests/unit/composables/usePermissions.test.ts
+++ b/tests/unit/composables/usePermissions.test.ts
@@ -35,6 +35,18 @@ describe('usePermissions.canRead', () => {
     expect(canRead('issue_37_test', 'anything')).toBe(true);
   });
 
+  // Directus reports `access: 'full'` even when the field-level whitelist is
+  // a restricted subset — `fields` stays the authoritative gate.
+  it('honours the field whitelist even when access is reported as full', () => {
+    mockPermissions.value.issue_37_test.read = {
+      access: 'full',
+      fields: ['id', 'title'],
+    };
+    const { canRead } = usePermissions();
+    expect(canRead('issue_37_test', 'title')).toBe(true);
+    expect(canRead('issue_37_test', 'thumbnail')).toBe(false);
+  });
+
   it('returns false when collection has access "none"', () => {
     mockPermissions.value.issue_37_test.read.access = 'none';
     const { canRead } = usePermissions();

--- a/tests/unit/composables/usePermissions.test.ts
+++ b/tests/unit/composables/usePermissions.test.ts
@@ -73,3 +73,55 @@ describe('usePermissions.getAccessibleLanguages', () => {
     expect(getAccessibleLanguages([{ code: 'de-DE', name: 'German' }])).toEqual([]);
   });
 });
+
+describe('usePermissions.sanitizeFields', () => {
+  beforeEach(() => {
+    mockPermissions.value = {
+      issue_37_test: {
+        read: { access: 'full', fields: ['id', 'title', 'translations'] },
+      },
+      issue_37_test_translations: {
+        read: { access: 'partial', fields: ['id', 'languages_code', 'text', 'description'] },
+      },
+    };
+  });
+
+  it('keeps fields the user can read', () => {
+    const { sanitizeFields } = usePermissions();
+    expect(sanitizeFields('issue_37_test', ['id', 'title'])).toEqual(['id', 'title']);
+  });
+
+  it('drops fields the user cannot read', () => {
+    const { sanitizeFields } = usePermissions();
+    expect(sanitizeFields('issue_37_test', ['id', 'title', 'thumbnail'])).toEqual(['id', 'title']);
+  });
+
+  it('keeps language-suffixed translation fields when sub-field is readable', () => {
+    const { sanitizeFields } = usePermissions();
+    expect(
+      sanitizeFields('issue_37_test', ['translations.text:de-DE', 'translations.text:en-GB'], {
+        translationsCollection: 'issue_37_test_translations',
+      })
+    ).toEqual(['translations.text:de-DE', 'translations.text:en-GB']);
+  });
+
+  it('drops language-suffixed fields when sub-field is not readable', () => {
+    mockPermissions.value.issue_37_test_translations.read.fields = ['id', 'languages_code', 'text'];
+    const { sanitizeFields } = usePermissions();
+    expect(
+      sanitizeFields('issue_37_test', ['translations.text:de-DE', 'translations.description:de-DE'], {
+        translationsCollection: 'issue_37_test_translations',
+      })
+    ).toEqual(['translations.text:de-DE']);
+  });
+
+  it('drops language-suffixed fields when language is not in accessibleLanguages', () => {
+    const { sanitizeFields } = usePermissions();
+    expect(
+      sanitizeFields('issue_37_test', ['translations.text:de-DE', 'translations.text:fr-FR'], {
+        translationsCollection: 'issue_37_test_translations',
+        accessibleLanguages: ['de-DE'],
+      })
+    ).toEqual(['translations.text:de-DE']);
+  });
+});

--- a/tests/unit/composables/usePermissions.test.ts
+++ b/tests/unit/composables/usePermissions.test.ts
@@ -51,3 +51,25 @@ describe('usePermissions.canRead', () => {
     expect(canRead('issue_37_test')).toBe(true);
   });
 });
+
+describe('usePermissions.getAccessibleLanguages', () => {
+  it('returns the list of language codes the user can read', () => {
+    mockPermissions.value = {
+      languages: { read: { access: 'partial', fields: ['*'] } },
+    };
+    const allLanguages = [
+      { code: 'de-DE', name: 'German' },
+      { code: 'en-GB', name: 'English' },
+      { code: 'fr-FR', name: 'Français' },
+    ];
+
+    const { getAccessibleLanguages } = usePermissions();
+    expect(getAccessibleLanguages(allLanguages)).toEqual(['de-DE', 'en-GB', 'fr-FR']);
+  });
+
+  it('returns empty array when user has no access to languages collection', () => {
+    mockPermissions.value = {};
+    const { getAccessibleLanguages } = usePermissions();
+    expect(getAccessibleLanguages([{ code: 'de-DE', name: 'German' }])).toEqual([]);
+  });
+});

--- a/tests/unit/composables/usePermissions.test.ts
+++ b/tests/unit/composables/usePermissions.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+
+const mockPermissions = ref<Record<string, any>>({});
+vi.mock('@directus/extensions-sdk', () => ({
+  useStores: () => ({
+    usePermissionsStore: () => ({ permissions: mockPermissions }),
+  }),
+}));
+
+import { usePermissions } from '../../../src/composables/usePermissions';
+
+describe('usePermissions.canRead', () => {
+  beforeEach(() => {
+    mockPermissions.value = {
+      issue_37_test: {
+        read: { access: 'full', fields: ['id', 'title', 'translations'] },
+      },
+    };
+  });
+
+  it('returns true when collection is readable and field is in whitelist', () => {
+    const { canRead } = usePermissions();
+    expect(canRead('issue_37_test', 'title')).toBe(true);
+  });
+
+  it('returns false when field is not in whitelist', () => {
+    const { canRead } = usePermissions();
+    expect(canRead('issue_37_test', 'thumbnail')).toBe(false);
+  });
+
+  it('returns true for any field when access is full and fields contains "*"', () => {
+    mockPermissions.value.issue_37_test.read.fields = ['*'];
+    const { canRead } = usePermissions();
+    expect(canRead('issue_37_test', 'anything')).toBe(true);
+  });
+
+  it('returns false when collection has access "none"', () => {
+    mockPermissions.value.issue_37_test.read.access = 'none';
+    const { canRead } = usePermissions();
+    expect(canRead('issue_37_test', 'title')).toBe(false);
+  });
+
+  it('returns false when collection is not in permissions map at all', () => {
+    const { canRead } = usePermissions();
+    expect(canRead('unknown_collection', 'title')).toBe(false);
+  });
+
+  it('returns true when called without a field if collection has any access', () => {
+    const { canRead } = usePermissions();
+    expect(canRead('issue_37_test')).toBe(true);
+  });
+});

--- a/tests/unit/composables/usePermissions.test.ts
+++ b/tests/unit/composables/usePermissions.test.ts
@@ -184,4 +184,27 @@ describe('usePermissions.sanitizeFields', () => {
       })
     ).toEqual(['translations.text:de-DE']);
   });
+
+  // Documents the contract: sanitizeFields treats every field the same way,
+  // including structural fields like the primary key and translation language
+  // code. The `fieldsWithRelational` caller in super-table.vue relies on this
+  // to fall back gracefully — when the user lacks read permission on the PK,
+  // sanitize drops it, the API request omits it, and the layout degrades the
+  // same way native Directus does (items render with limited interaction
+  // instead of an empty 403 error state).
+  it('drops the primary key when it is not in the read whitelist (graceful degradation)', () => {
+    mockPermissions.value.issue_37_test.read.fields = ['title'];
+    const { sanitizeFields } = usePermissions();
+    expect(sanitizeFields('issue_37_test', ['id', 'title'])).toEqual(['title']);
+  });
+
+  it('drops translations.languages_code when sub-field is not in the junction whitelist (graceful degradation)', () => {
+    mockPermissions.value.issue_37_test_translations.read.fields = ['id', 'text'];
+    const { sanitizeFields } = usePermissions();
+    expect(
+      sanitizeFields('issue_37_test', ['translations.languages_code', 'translations.text'], {
+        translationsCollection: 'issue_37_test_translations',
+      })
+    ).toEqual(['translations.text']);
+  });
 });

--- a/tests/unit/composables/usePermissions.test.ts
+++ b/tests/unit/composables/usePermissions.test.ts
@@ -52,6 +52,66 @@ describe('usePermissions.canRead', () => {
   });
 });
 
+describe('usePermissions.canUpdate / canCreate / canDelete', () => {
+  beforeEach(() => {
+    mockPermissions.value = {
+      issue_37_test: {
+        read: { access: 'full', fields: ['*'] },
+        update: { access: 'partial', fields: ['title', 'status'] },
+        create: { access: 'full' },
+        delete: { access: 'none' },
+      },
+    };
+  });
+
+  it('canUpdate returns true when field is in update whitelist', () => {
+    const { canUpdate } = usePermissions();
+    expect(canUpdate('issue_37_test', 'title')).toBe(true);
+  });
+
+  it('canUpdate returns false when field is not in update whitelist', () => {
+    const { canUpdate } = usePermissions();
+    expect(canUpdate('issue_37_test', 'thumbnail')).toBe(false);
+  });
+
+  it('canUpdate returns false when collection has no update entry', () => {
+    const { canUpdate } = usePermissions();
+    expect(canUpdate('unknown_collection', 'title')).toBe(false);
+  });
+
+  it('canCreate returns true when collection has create access', () => {
+    const { canCreate } = usePermissions();
+    expect(canCreate('issue_37_test')).toBe(true);
+  });
+
+  it('canCreate returns false when collection has no create entry', () => {
+    const { canCreate } = usePermissions();
+    expect(canCreate('unknown_collection')).toBe(false);
+  });
+
+  it('canDelete returns false when delete access is "none"', () => {
+    const { canDelete } = usePermissions();
+    expect(canDelete('issue_37_test')).toBe(false);
+  });
+});
+
+describe('usePermissions shape resilience', () => {
+  it('returns false when permissions store exposes an array (legacy shape)', () => {
+    mockPermissions.value = [] as any;
+    const { canRead, canUpdate, canCreate, canDelete } = usePermissions();
+    expect(canRead('issue_37_test', 'title')).toBe(false);
+    expect(canUpdate('issue_37_test', 'title')).toBe(false);
+    expect(canCreate('issue_37_test')).toBe(false);
+    expect(canDelete('issue_37_test')).toBe(false);
+  });
+
+  it('returns false when permissions store is null/undefined', () => {
+    mockPermissions.value = null as any;
+    const { canRead } = usePermissions();
+    expect(canRead('issue_37_test', 'title')).toBe(false);
+  });
+});
+
 describe('usePermissions.getAccessibleLanguages', () => {
   it('returns the list of language codes the user can read', () => {
     mockPermissions.value = {

--- a/tests/unit/composables/useTranslationLanguages.test.ts
+++ b/tests/unit/composables/useTranslationLanguages.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref, nextTick } from 'vue';
+
+const mockApiGet = vi.fn();
+vi.mock('@directus/extensions-sdk', () => ({
+  useApi: () => ({ get: mockApiGet }),
+}));
+
+import { useTranslationLanguages } from '../../../src/composables/useTranslationLanguages';
+
+describe('useTranslationLanguages', () => {
+  beforeEach(() => {
+    mockApiGet.mockReset();
+  });
+
+  it('returns the languages found in the translations collection', async () => {
+    mockApiGet.mockResolvedValue({
+      data: {
+        data: [
+          { languages_code: 'de-DE', count: { '*': 3 } },
+          { languages_code: 'en-GB', count: { '*': 3 } },
+        ],
+      },
+    });
+
+    const collection = ref<string | null>('issue_37_test_translations');
+    const codeField = ref('languages_code');
+    const { probedLanguages, probe } = useTranslationLanguages(collection, codeField);
+
+    await probe();
+
+    expect(probedLanguages.value).toEqual(['de-DE', 'en-GB']);
+    expect(mockApiGet).toHaveBeenCalledWith('/items/issue_37_test_translations', {
+      params: { aggregate: { count: '*' }, groupBy: ['languages_code'], limit: -1 },
+    });
+  });
+
+  it('returns null when the API call fails', async () => {
+    mockApiGet.mockRejectedValue(new Error('403 Forbidden'));
+
+    const collection = ref<string | null>('issue_37_test_translations');
+    const codeField = ref('languages_code');
+    const { probedLanguages, probe } = useTranslationLanguages(collection, codeField);
+
+    await probe();
+
+    expect(probedLanguages.value).toBeNull();
+  });
+
+  it('returns null when the collection has no rows (empty fresh install)', async () => {
+    mockApiGet.mockResolvedValue({ data: { data: [] } });
+
+    const collection = ref<string | null>('issue_37_test_translations');
+    const codeField = ref('languages_code');
+    const { probedLanguages, probe } = useTranslationLanguages(collection, codeField);
+
+    await probe();
+
+    expect(probedLanguages.value).toBeNull();
+  });
+
+  it('skips the probe when collection is null', async () => {
+    const collection = ref<string | null>(null);
+    const codeField = ref('languages_code');
+    const { probedLanguages, probe } = useTranslationLanguages(collection, codeField);
+
+    await probe();
+
+    expect(probedLanguages.value).toBeNull();
+    expect(mockApiGet).not.toHaveBeenCalled();
+  });
+
+  it('uses a custom language code field when provided', async () => {
+    mockApiGet.mockResolvedValue({
+      data: { data: [{ lang: 'de-DE', count: { '*': 1 } }] },
+    });
+
+    const collection = ref<string | null>('custom_translations');
+    const codeField = ref('lang');
+    const { probedLanguages, probe } = useTranslationLanguages(collection, codeField);
+
+    await probe();
+
+    expect(probedLanguages.value).toEqual(['de-DE']);
+    expect(mockApiGet).toHaveBeenCalledWith('/items/custom_translations', {
+      params: { aggregate: { count: '*' }, groupBy: ['lang'], limit: -1 },
+    });
+  });
+
+  it('re-probes when the translationsCollection ref changes', async () => {
+    mockApiGet
+      .mockResolvedValueOnce({ data: { data: [{ languages_code: 'fr-FR' }] } });
+
+    const collection = ref<string | null>('first_translations');
+    const codeField = ref('languages_code');
+    const { probedLanguages } = useTranslationLanguages(collection, codeField);
+
+    // Initial probe is deferred to onMounted (not invoked in unit test).
+    expect(probedLanguages.value).toBeNull();
+
+    // Changing the ref triggers the watcher.
+    collection.value = 'second_translations';
+    await nextTick();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(probedLanguages.value).toEqual(['fr-FR']);
+  });
+});

--- a/tests/unit/utils/resolveTranslationValue.test.ts
+++ b/tests/unit/utils/resolveTranslationValue.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { resolveTranslationValue } from '../../../src/utils/resolveTranslationValue';
+
+describe('resolveTranslationValue', () => {
+  it('returns text string for normal translation', () => {
+    const item = { translations: [{ text: 'Hello', languages_code: 'en-GB' }] };
+    expect(resolveTranslationValue(item, 'translations.text', 'en-GB', 'languages_code')).toBe(
+      'Hello'
+    );
+  });
+
+  it('returns null for unknown language', () => {
+    const item = { translations: [{ text: 'Hello', languages_code: 'en-GB' }] };
+    expect(
+      resolveTranslationValue(item, 'translations.text', 'fr-FR', 'languages_code')
+    ).toBeNull();
+  });
+
+  it('returns null when item has no translations', () => {
+    expect(resolveTranslationValue({}, 'translations.text', 'en-GB', 'languages_code')).toBeNull();
+  });
+
+  it('extracts .text when value is accidentally a translation object', () => {
+    const item = {
+      translations: [
+        {
+          text: { text: 'Nested!', languages_code: 'en-GB' },
+          languages_code: 'en-GB',
+        },
+      ],
+    };
+    expect(resolveTranslationValue(item, 'translations.text', 'en-GB', 'languages_code')).toBe(
+      'Nested!'
+    );
+  });
+
+  it('returns null for missing language argument', () => {
+    const item = { translations: [{ text: 'Hello', languages_code: 'en-GB' }] };
+    expect(resolveTranslationValue(item, 'translations.text', null, 'languages_code')).toBeNull();
+  });
+});

--- a/tests/unit/utils/sanitizeFilter.test.ts
+++ b/tests/unit/utils/sanitizeFilter.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeFilter } from '../../../src/utils/sanitizeFilter';
+
+describe('sanitizeFilter', () => {
+  const canRead = (field: string) => ['title', 'id'].includes(field);
+
+  it('returns null for null input', () => {
+    expect(sanitizeFilter(null, canRead)).toEqual({ sanitized: null, removed: [] });
+  });
+
+  it('keeps simple condition on accessible field', () => {
+    const filter = { title: { _eq: 'foo' } };
+    expect(sanitizeFilter(filter, canRead)).toEqual({ sanitized: filter, removed: [] });
+  });
+
+  it('drops simple condition on inaccessible field', () => {
+    const filter = { thumbnail: { _nnull: true } };
+    expect(sanitizeFilter(filter, canRead)).toEqual({ sanitized: null, removed: ['thumbnail'] });
+  });
+
+  it('drops branches inside _and that reference inaccessible fields', () => {
+    const filter = {
+      _and: [{ title: { _eq: 'foo' } }, { thumbnail: { _nnull: true } }],
+    };
+    expect(sanitizeFilter(filter, canRead)).toEqual({
+      sanitized: { _and: [{ title: { _eq: 'foo' } }] },
+      removed: ['thumbnail'],
+    });
+  });
+
+  it('returns null when _and becomes empty after sanitization', () => {
+    const filter = { _and: [{ thumbnail: { _nnull: true } }] };
+    expect(sanitizeFilter(filter, canRead)).toEqual({ sanitized: null, removed: ['thumbnail'] });
+  });
+
+  it('handles nested _or inside _and', () => {
+    const filter = {
+      _and: [{ _or: [{ thumbnail: { _eq: 'a' } }, { title: { _eq: 'b' } }] }],
+    };
+    expect(sanitizeFilter(filter, canRead)).toEqual({
+      sanitized: { _and: [{ _or: [{ title: { _eq: 'b' } }] }] },
+      removed: ['thumbnail'],
+    });
+  });
+});

--- a/tests/unit/utils/sanitizeFilter.test.ts
+++ b/tests/unit/utils/sanitizeFilter.test.ts
@@ -43,3 +43,89 @@ describe('sanitizeFilter', () => {
     });
   });
 });
+
+describe('sanitizeFilter with nestedScopes (translation sub-fields)', () => {
+  // Caller mirrors the real super-table.vue wiring: parent collection is
+  // 'pages'; the translations junction is 'pages_translations'. The user
+  // can read `text` in the junction but not `description`.
+  const canRead = (field: string, scope?: string) => {
+    if (scope === 'pages_translations') return field === 'text';
+    return ['title', 'translations', 'id'].includes(field);
+  };
+  const opts = { nestedScopes: { translations: 'pages_translations' } };
+
+  it('keeps allowed sub-field inside _some on translations', () => {
+    const filter = { translations: { _some: { text: { _icontains: 'foo' } } } };
+    expect(sanitizeFilter(filter, canRead, opts)).toEqual({
+      sanitized: { translations: { _some: { text: { _icontains: 'foo' } } } },
+      removed: [],
+    });
+  });
+
+  it('drops disallowed sub-field inside _some, dropping the whole translations clause', () => {
+    const filter = { translations: { _some: { description: { _icontains: 'foo' } } } };
+    expect(sanitizeFilter(filter, canRead, opts)).toEqual({
+      sanitized: null,
+      removed: ['description'],
+    });
+  });
+
+  it('keeps allowed sibling and drops disallowed sibling inside _some', () => {
+    const filter = {
+      translations: {
+        _some: {
+          text: { _icontains: 'foo' },
+          description: { _icontains: 'bar' },
+        },
+      },
+    };
+    expect(sanitizeFilter(filter, canRead, opts)).toEqual({
+      sanitized: { translations: { _some: { text: { _icontains: 'foo' } } } },
+      removed: ['description'],
+    });
+  });
+
+  it('drops translation branch inside _or while keeping accessible siblings', () => {
+    const filter = {
+      _or: [
+        { translations: { _some: { description: { _icontains: 'foo' } } } },
+        { title: { _icontains: 'foo' } },
+      ],
+    };
+    expect(sanitizeFilter(filter, canRead, opts)).toEqual({
+      sanitized: { _or: [{ title: { _icontains: 'foo' } }] },
+      removed: ['description'],
+    });
+  });
+
+  it('handles _none and _every relation match operators', () => {
+    const filter = {
+      _and: [
+        { translations: { _none: { description: { _eq: 'spam' } } } },
+        { translations: { _every: { text: { _nnull: true } } } },
+      ],
+    };
+    expect(sanitizeFilter(filter, canRead, opts)).toEqual({
+      sanitized: { _and: [{ translations: { _every: { text: { _nnull: true } } } }] },
+      removed: ['description'],
+    });
+  });
+
+  it('passes through when no nestedScopes configured (backward compatibility)', () => {
+    // Without nestedScopes, the walker treats translations as a leaf field.
+    // Permission only checks the parent-level field, not sub-fields.
+    const filter = { translations: { _some: { description: { _icontains: 'foo' } } } };
+    expect(sanitizeFilter(filter, canRead)).toEqual({
+      sanitized: filter,
+      removed: [],
+    });
+  });
+
+  it('does not require translations scope when filter touches only parent fields', () => {
+    const filter = { _and: [{ title: { _eq: 'foo' } }, { id: { _eq: 1 } }] };
+    expect(sanitizeFilter(filter, canRead, opts)).toEqual({
+      sanitized: filter,
+      removed: [],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes Issue #37 — adds permission-aware filtering across the entire Super Layout Table pipeline.

Closes #37.

## Changes
- New `usePermissions` composable + `sanitizeFilter` utility (single source of truth)
- Translation language columns hidden when user can't read the language
- Inline-edit popover gated on `canUpdate`
- Filter sanitization with user notification
- Bulk-action duplicate button hidden when no create permission
- Display bug `[object Object]` fixed
- 403 errors surface as notifications

## Test plan
- [x] Unit tests: `usePermissions`, `sanitizeFilter`, `resolveTranslationValue` (120/120 passing)
- [x] Manual: bookmark 137 as `issue37@test.com` (limited user)
- [x] Manual: bookmark 137 as admin
- [x] Quality checks: `pnpm run quality`