### PR TITLE
Hotfix v0.4.2: Marketplace metadata cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Super Layout Table Extension will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.2 — Marketplace metadata
+
+### Changed
+- Added `icon: 'table_rows'` to package.json for better Marketplace
+  presentation.
+- Removed the hard-coded version line from README — version history is
+  tracked in CHANGELOG, the README copy was always lagging.
+
 ## v0.4.1 — Hotfix: M2M pivot 403 + collection-switch (Issue #55)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ A powerful and feature-rich table layout extension for Directus 11+ that enhance
 
 ![Super Table Demo](https://raw.githubusercontent.com/smartlabsAT/directus-super-table/main/demo/super-table-demo.gif)
 
-## Version
-
-v0.3.1 - Stable release
+See [CHANGELOG.md](./CHANGELOG.md) for version history.
 
 ## 🌟 Top Features
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "directus-extension-super-table",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A powerful and feature-rich table layout extension for Directus 11+ with inline editing, quick filters, and manual sorting",
+  "icon": "table_rows",
   "keywords": [
     "directus",
     "directus-extension",


### PR DESCRIPTION
## Summary

Small follow-up after v0.4.1 to improve the Directus Marketplace listing.

### Changes
- **`icon: 'table_rows'`** added to package.json — the Material-Icons name shows up in the Marketplace tile.
- **Removed the stale `## Version` block** from README. It hard-coded `v0.3.1 - Stable release` and was already 4 versions out of date when the Registry last fetched the README. Version history lives in CHANGELOG.

### Why
Reported via Marketplace UI still showing older versions; the Registry sync pulls fresh metadata + README on each new version, so we want the README to be self-documenting via the linked CHANGELOG instead of carrying its own version number.

## Test plan
- [x] `pnpm quality` clean
- [x] `pnpm build` succeeds
- [x] No runtime code changes — purely metadata.