### PR TITLE
Feature: Deep relational paths in M2A templates (nested translations) — v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   forward `update:search` from layouts. The header pill's own little result
   badge is computed by Directus core with native search semantics and can
   undercount (e.g. translation-only matches); the table and its pagination
-  use the layout's filter and are authoritative.
+  use the layout's filter and are authoritative. For the same reason, clearing
+  the search from inside the layout cannot clear the native header pill — the
+  table filters correctly, but the pill keeps its text until cleared natively.
 - **Item count no longer double-applies the search.** The count request passed
   the search as a native `search` param on top of the `_or` filter, so counts
   could disagree with the visible rows (native search misses translations /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the Super Layout Table Extension will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.6.0 — Deep relational paths in M2A templates (nested translations)
+
+### Added
+- **M2A templates resolve deep relational paths**, including a `translations`
+  relation stored *inside* the target collection — e.g.
+  `{{item:service.translations.label}}` (M2A → target → translations → value).
+  Resolution is generic and schema-driven: each hop is interpreted via the
+  relations store, so it scales to arbitrary depth (M2O chains, files, nested
+  translations) without per-level special-casing.
+- **Per-relation language-field detection.** The translation language column is
+  read from the relation (its `junction_field`), not hardcoded — so collections
+  using a non-default language field still resolve.
+- **Language selection for nested translations.** An optional `:lang` suffix on
+  the token (`…translations.label:de-DE`) picks the language; without it the
+  current user's language is used, falling back to the first available row.
+
+Requested by @Abdallah-Awwad as a follow-up to #60.
+
 ## v0.5.1 — M2A picker templates, field scopes & guard fix (Issue #60)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the token (`…translations.label:de-DE`) picks the language; without it the
   current user's language is used, falling back to the first available row.
 
+### Fixed
+- **Invalid deep template fields no longer blank the view.** Every segment of
+  an `item:collection.path` token is now validated against the schema before
+  the request is built; unknown fields are dropped with a `console.warn`
+  (`[super-layout-table] Dropped template field …`) and the cell degrades to
+  an empty value — previously the API rejected the whole request (403) and the
+  table rendered zero rows with no hint.
+- **HTML translation values render as plain text in M2A cells.** Resolved
+  template values are stripped of HTML tags (entities decoded, script/style
+  contents dropped), matching the native `formatted-value` display used by
+  regular columns; raw `<p data-start=…>` markup is no longer shown.
+- **Nested to-many relations inside M2A items are fetched unbounded.** The
+  items request now emits `deep[<field>][item:<collection>][<relation>][_limit]=-1`
+  for every to-many hop crossed by an expanded template path, so e.g. a
+  translations set larger than the server's default page size (100) is no
+  longer silently truncated.
+
 Requested by @Abdallah-Awwad as a follow-up to #60.
 
 ## v0.5.1 — M2A picker templates, field scopes & guard fix (Issue #60)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`{{treatment.x.y}}`), parent, M2M and M2O/O2M/files tokens are now walked
   segment by segment like M2A item tokens (translations keep their deliberate
   client-side tolerance). Drop warnings are deduplicated per session.
+- **Column Display Template editor: lossless textarea + field picker.** The
+  native chip editor silently dropped the extension-only `:lang` suffix on
+  nested-translation tokens (and re-serialized it away on edit). It is replaced
+  by a plain textarea (every token visible, lossless round-trip) plus a
+  schema-driven "+" field picker: for M2A columns it drills target collections
+  incl. nested translations and offers an inline language choice (inserting the
+  full `…:de-DE` token); for other relational columns it inserts relative
+  tokens. Scalar / per-language translation columns show the textarea only.
 
 Requested by @Abdallah-Awwad as a follow-up to #60.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for every to-many hop crossed by an expanded template path, so e.g. a
   translations set larger than the server's default page size (100) is no
   longer silently truncated.
+- **The native header search now drives the layout.** It previously had no
+  effect in this layout (only the toolbar search filtered). Native input is
+  mirrored into the layout search (same intelligent `_or` filter, incl.
+  translations/UUID/integer handling). Note: the reverse direction (toolbar →
+  native header pill) is not possible — the Directus layout wrapper does not
+  forward `update:search` from layouts. The header pill's own little result
+  badge is computed by Directus core with native search semantics and can
+  undercount (e.g. translation-only matches); the table and its pagination
+  use the layout's filter and are authoritative.
+- **Item count no longer double-applies the search.** The count request passed
+  the search as a native `search` param on top of the `_or` filter, so counts
+  could disagree with the visible rows (native search misses translations /
+  UUID / integer matches). The count now uses exactly the list's filter.
+  Counts over to-many search filters (e.g. translations) now use a distinct
+  count, so a single match with several translations no longer inflates the
+  total.
+- **Exactly one fetch per change.** Bookmark loads fired three identical
+  items+count request pairs (identity churn after async language hydration),
+  template edits fired two (duplicate watcher), and every layout-options write
+  (column width, alignment, edit mode) triggered a needless refetch. A content
+  fingerprint plus a coalescing single-flight runner reduce all of these to a
+  single request pair — and overlapping responses can no longer arrive out of
+  order.
+- **Per-segment template validation covers all relational branches.** Junction
+  (`{{treatment.x.y}}`), parent, M2M and M2O/O2M/files tokens are now walked
+  segment by segment like M2A item tokens (translations keep their deliberate
+  client-side tolerance). Drop warnings are deduplicated per session.
 
 Requested by @Abdallah-Awwad as a follow-up to #60.
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ name clash the most specific (deepest) match wins:
 - **Deep paths through the target work too**, including a `translations`
   relation stored inside the target: `{{item:service.translations.label}}`.
   Add a `:lang` suffix to choose the language (`…translations.label:de-DE`);
-  without it the current user's language is used.
+  without it the current user's language is used. The `:lang` suffix is
+  honored on M2A `item:` tokens only; on other relational columns it is not
+  interpreted (and an invalid path is dropped rather than sent to the API).
 
 Each junction row only resolves the item token whose `<collection>` matches its own
 target, so a template can cover every allowed collection at once:

--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ name clash the most specific (deepest) match wins:
   column like `{{treatment.sort}}`
 - `{{<parentField>}}` — a bare token reads a field on the parent row, e.g.
   `{{code}}` shows the order's own code next to each item
+- **Deep paths through the target work too**, including a `translations`
+  relation stored inside the target: `{{item:service.translations.label}}`.
+  Add a `:lang` suffix to choose the language (`…translations.label:de-DE`);
+  without it the current user's language is used.
 
 Each junction row only resolves the item token whose `<collection>` matches its own
 target, so a template can cover every allowed collection at once:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -118,6 +118,7 @@ export default [
         clearTimeout: 'readonly',
         navigator: 'readonly',
         HTMLInputElement: 'readonly',
+        HTMLTextAreaElement: 'readonly',
         EventListener: 'readonly',
       },
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-super-table",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A powerful and feature-rich table layout extension for Directus 11+ with inline editing, quick filters, and manual sorting",
   "icon": "table_rows",
   "keywords": [

--- a/src/components/ColumnDisplayEditor.vue
+++ b/src/components/ColumnDisplayEditor.vue
@@ -13,19 +13,37 @@
 
     <div class="field">
       <div class="label">
-        Display Template
+        <span>Display Template</span>
         <v-icon v-if="m2aHelp" v-tooltip="m2aHelp.tooltip" name="help" small class="help-icon" />
+        <div class="spacer" />
+        <TemplateFieldPicker
+          v-if="pickerContext"
+          :context="pickerContext"
+          :languages="languages"
+          @select="insertToken"
+        />
       </div>
-      <interface-system-display-template
-        :collection-name="targetCollection"
-        :value="form.template"
+      <!-- Plain-text editor: the native chip editor (system-display-template)
+           silently drops the extension-only `:lang` suffix on nested-translation
+           tokens and would re-serialize it away on edit (data loss). A raw
+           textarea round-trips the template losslessly and keeps every token
+           visible. -->
+      <v-textarea
+        ref="templateRef"
+        :model-value="form.template"
         placeholder="{{ field }}"
-        :include-relations="true"
-        @input="form.template = $event ?? ''"
+        :nullable="false"
+        @update:model-value="form.template = $event ?? ''"
       />
-      <div v-if="m2aHelp" class="hint">
-        Many-to-Any field — pick fields from the tree, or write
-        <code>{{ itemToken }}</code> by hand.
+      <div class="hint">
+        Write the template with <code>{{ fieldToken }}</code> tokens.
+        <template v-if="m2aHelp">
+          For this Many-to-Any field use <code>{{ collectionToken }}</code> and
+          <code>{{ itemToken }}</code
+          >; add a <code>:lang</code> suffix to pin a nested-translation language (e.g.
+          <code>{{ langExampleToken }}</code
+          >).
+        </template>
       </div>
     </div>
 
@@ -37,11 +55,18 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watch } from 'vue';
+import { computed, ref, watch, onMounted, nextTick } from 'vue';
 import { useStores } from '@directus/extensions-sdk';
 import type { ColumnDisplay } from '../composables/useColumnDisplays';
-import { isRelational, isM2A, resolveTargetCollection } from '../utils/displayHeuristics';
+import {
+  isM2A,
+  isRelational,
+  resolveTargetCollection,
+  stripLanguageSuffix,
+} from '../utils/displayHeuristics';
 import { resolveM2ARelation } from '../utils/resolveM2ARelation';
+import { useLanguageSelector } from '../composables/useLanguageSelector';
+import TemplateFieldPicker from './TemplateFieldPicker.vue';
 
 const props = defineProps<{
   mode: 'add' | 'edit';
@@ -65,25 +90,72 @@ const form = ref<{ fieldKey: string; template: string }>({
   template: props.initialValue?.template ?? '',
 });
 
-const targetCollection = computed(() => {
-  if (!form.value.fieldKey) return null;
-  // Strip language suffix (translations.title:de-DE → translations.title)
-  const rootKey = form.value.fieldKey.includes(':')
-    ? form.value.fieldKey.split(':')[0]
-    : form.value.fieldKey;
-  // Use root field on the parent for relational lookup
-  const rootField = rootKey.split('.')[0];
-  const fieldDef = fieldsStore.getField(props.collection, rootField);
-  if (!fieldDef) return props.collection;
-  if (!isRelational(fieldDef)) return props.collection;
-  const target = resolveTargetCollection(fieldDef, relationsStore as any, fieldsStore as any);
-  return target ?? props.collection;
+const { languages, fetchLanguages } = useLanguageSelector();
+onMounted(() => {
+  void fetchLanguages();
 });
 
-// Literal token examples for the M2A help notice (kept out of the template so
-// the mustache braces aren't parsed as Vue interpolation).
+// Field picker context derived from the column's relation type. Null → no
+// picker button (scalar / per-language translation columns: a token template
+// doesn't apply there).
+const pickerContext = computed(() => {
+  if (!form.value.fieldKey) return null;
+  const rootField = stripLanguageSuffix(form.value.fieldKey).split('.')[0];
+  if (!rootField) return null;
+  const fieldDef = fieldsStore.getField(props.collection, rootField);
+  if (!fieldDef) return null;
+  if (isM2A(fieldDef)) {
+    const m2a = resolveM2ARelation(props.collection, rootField, relationsStore, fieldsStore);
+    if (!m2a) return null;
+    return {
+      mode: 'm2a' as const,
+      fieldKey: rootField,
+      allowedCollections: m2a.allowedCollections,
+    };
+  }
+  if (isRelational(fieldDef)) {
+    // Per-language translation columns render via resolveTranslationValue (the
+    // column key carries the language), not via a token template — so a picker
+    // would only insert dead tokens. No button there.
+    if (fieldDef.meta?.special?.includes('translations')) return null;
+    const related = resolveTargetCollection(fieldDef, relationsStore as any, fieldsStore as any);
+    if (!related) return null;
+    return { mode: 'relative' as const, relatedCollection: related };
+  }
+  return null;
+});
+
+const templateRef = ref<any>(null);
+function innerTextarea(): HTMLTextAreaElement | null {
+  const root = templateRef.value?.$el as HTMLElement | undefined;
+  return (root?.querySelector('textarea') as HTMLTextAreaElement) ?? null;
+}
+
+// Insert a picker token at the textarea's last caret position (a blurred
+// textarea retains its selection), replacing any selection. Falls back to
+// appending. The textarea stays the lossless source of truth.
+function insertToken(token: string) {
+  const el = innerTextarea();
+  const current = form.value.template;
+  const start = el ? (el.selectionStart ?? current.length) : current.length;
+  const end = el ? (el.selectionEnd ?? current.length) : current.length;
+  form.value.template = current.slice(0, start) + token + current.slice(end);
+  void nextTick(() => {
+    const after = innerTextarea();
+    if (after) {
+      const caret = start + token.length;
+      after.focus();
+      after.setSelectionRange(caret, caret);
+    }
+  });
+}
+
+// Literal token examples for the help notice (kept out of the template so the
+// mustache braces aren't parsed as Vue interpolation).
+const fieldToken = '{{ field }}';
 const collectionToken = '{{collection}}';
 const itemToken = '{{item:<collection>.<field>}}';
+const langExampleToken = '{{item:<collection>.translations.<field>:de-DE}}';
 
 // The system display-template picker can't introspect the polymorphic M2A
 // target, so guide the user to the `item:collection.field` token syntax.
@@ -103,7 +175,7 @@ const m2aHelp = computed(() => {
     : '{{collection}}: {{item:<collection>.name}}';
   const allowed = collections.length ? `Allowed collections: ${collections.join(', ')}. ` : '';
   const tooltip =
-    `Many-to-Any field. Pick fields from the template tree, or write tokens by hand: ` +
+    `Many-to-Any field. Write tokens by hand: ` +
     `${collectionToken} for the target collection and ${itemToken} for its values. ` +
     `${allowed}Example: ${example}`;
   return { tooltip };
@@ -155,6 +227,9 @@ watch(
   color: var(--foreground-normal);
   font-weight: 600;
   font-size: 13px;
+}
+.label .spacer {
+  flex: 1 1 auto;
 }
 .help-icon {
   --v-icon-color: var(--foreground-subdued);

--- a/src/components/EditableCellRelational.vue
+++ b/src/components/EditableCellRelational.vue
@@ -193,13 +193,23 @@ import { isFieldEditable, getFieldEditWarning, getFieldSupportLevel } from '../u
 import { pickHeuristic, isM2A } from '../utils/displayHeuristics';
 import { resolveM2ARelation } from '../utils/resolveM2ARelation';
 import { buildM2ASegments, isBlockedSegment, type M2ASegment } from '../utils/buildM2ASegments';
+import { createDescribeHop } from '../utils/describeHop';
 import { resolveTranslationValue } from '../utils/resolveTranslationValue';
 import { usePermissions } from '../composables/usePermissions';
 
-const { useFieldsStore, useRelationsStore } = useStores();
+const { useFieldsStore, useRelationsStore, useUserStore } = useStores();
 const fieldsStore = useFieldsStore();
 const relationsStore = useRelationsStore();
 const permissions = usePermissions();
+const userStore = useUserStore?.();
+
+// Schema-aware hop resolver so M2A templates can reach deep relations
+// (e.g. translations stored inside the target collection).
+const describeHop = createDescribeHop(fieldsStore, relationsStore);
+
+// Default language for nested translations when a token carries no `:lang`
+// suffix: the current user's language (falls back to the first row).
+const defaultLanguage = (): string | null => (userStore as any)?.currentUser?.language ?? null;
 
 const props = defineProps<{
   item: Item;
@@ -427,7 +437,8 @@ const m2aSegments = computed<M2ASegment[]>(() => {
     m2a.discriminator,
     String(fieldName),
     props.item,
-    (c) => permissions.canRead(c)
+    (c) => permissions.canRead(c),
+    { describeHop, language: defaultLanguage() }
   );
 });
 

--- a/src/components/TemplateFieldPicker.vue
+++ b/src/components/TemplateFieldPicker.vue
@@ -1,0 +1,211 @@
+<template>
+  <v-menu v-model="open" placement="bottom-start" :close-on-content-click="false">
+    <template #activator="{ toggle }">
+      <v-icon
+        v-tooltip="'Insert field'"
+        name="add"
+        small
+        clickable
+        class="insert-field"
+        @click="toggle"
+      />
+    </template>
+
+    <v-list>
+      <template v-if="canGoBack">
+        <v-list-item clickable @click="goBack">
+          <v-list-item-icon><v-icon name="arrow_back" small /></v-list-item-icon>
+          <v-list-item-content>Back</v-list-item-content>
+        </v-list-item>
+        <v-divider />
+      </template>
+
+      <!-- Language step (M2A nested translation) -->
+      <template v-if="langView">
+        <v-list-item clickable @click="pickLanguage(null)">
+          <v-list-item-content>Current user's language</v-list-item-content>
+        </v-list-item>
+        <v-list-item v-for="l in languages" :key="l.code" clickable @click="pickLanguage(l.code)">
+          <v-list-item-content>{{ l.name || l.code }}</v-list-item-content>
+        </v-list-item>
+      </template>
+
+      <!-- M2A root: discriminator + allowed target collections -->
+      <template v-else-if="isM2ARoot">
+        <v-list-item clickable @click="emitDiscriminator">
+          <v-list-item-icon><v-icon name="category" small /></v-list-item-icon>
+          <v-list-item-content>Collection</v-list-item-content>
+        </v-list-item>
+        <v-list-item v-for="c in m2aCollections" :key="c" clickable @click="enterCollection(c)">
+          <v-list-item-icon><v-icon name="chevron_right" small /></v-list-item-icon>
+          <v-list-item-content>{{ titleCase(c) }}</v-list-item-content>
+        </v-list-item>
+      </template>
+
+      <!-- Fields of the current collection -->
+      <template v-else>
+        <v-list-item v-if="fields.length === 0" disabled>
+          <v-list-item-content>No fields</v-list-item-content>
+        </v-list-item>
+        <v-list-item v-for="e in fields" :key="e.field" clickable @click="onEntry(e)">
+          <v-list-item-icon
+            ><v-icon :name="e.drillable ? 'chevron_right' : 'label'" small
+          /></v-list-item-icon>
+          <v-list-item-content>{{ titleCase(e.label) }}</v-list-item-content>
+        </v-list-item>
+      </template>
+    </v-list>
+  </v-menu>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed, watch } from 'vue';
+import { useStores } from '@directus/extensions-sdk';
+import { formatTitle } from '@directus/format-title';
+import { createDescribeHop } from '../utils/describeHop';
+import { listPickerFields, type PickerEntry } from '../utils/listPickerFields';
+import { buildTemplateToken } from '../utils/buildTemplateToken';
+
+type PickerContext =
+  | { mode: 'm2a'; fieldKey: string; allowedCollections: string[] }
+  | { mode: 'relative'; relatedCollection: string };
+
+const props = defineProps<{
+  context: PickerContext;
+  languages: Array<{ code: string; name?: string }>;
+}>();
+
+const emit = defineEmits<{ (e: 'select', token: string): void }>();
+
+const { useFieldsStore, useRelationsStore } = useStores();
+const fieldsStore = useFieldsStore();
+const relationsStore = useRelationsStore();
+const describeHop = createDescribeHop(fieldsStore, relationsStore);
+
+const open = ref(false);
+
+interface Frame {
+  collection: string;
+  segments: string[];
+  withinTranslations: boolean;
+  targetCollection: string;
+}
+const stack = ref<Frame[]>([]);
+const langView = ref<{ path: string; targetCollection: string } | null>(null);
+
+function reset() {
+  langView.value = null;
+  stack.value =
+    props.context.mode === 'relative'
+      ? [
+          {
+            collection: props.context.relatedCollection,
+            segments: [],
+            withinTranslations: false,
+            targetCollection: '',
+          },
+        ]
+      : [];
+}
+watch(open, (isOpen) => {
+  if (isOpen) reset();
+});
+
+const isM2ARoot = computed(
+  () => props.context.mode === 'm2a' && stack.value.length === 0 && !langView.value
+);
+const m2aCollections = computed(() =>
+  props.context.mode === 'm2a' ? props.context.allowedCollections : []
+);
+const canGoBack = computed(
+  () => !!langView.value || stack.value.length > (props.context.mode === 'relative' ? 1 : 0)
+);
+const fields = computed<PickerEntry[]>(() => {
+  if (langView.value || isM2ARoot.value) return [];
+  const frame = stack.value[stack.value.length - 1];
+  return frame ? listPickerFields(frame.collection, describeHop, fieldsStore) : [];
+});
+
+function titleCase(s: string): string {
+  return formatTitle(s);
+}
+
+function enterCollection(collection: string) {
+  stack.value.push({
+    collection,
+    segments: [],
+    withinTranslations: false,
+    targetCollection: collection,
+  });
+}
+
+function onEntry(e: PickerEntry) {
+  const frame = stack.value[stack.value.length - 1];
+  if (!frame) return;
+  if (e.drillable && e.relatedCollection) {
+    stack.value.push({
+      collection: e.relatedCollection,
+      segments: [...frame.segments, e.field],
+      withinTranslations: frame.withinTranslations || e.isTranslationsHop,
+      targetCollection: frame.targetCollection,
+    });
+    return;
+  }
+  const path = [...frame.segments, e.field].join('.');
+  if (props.context.mode === 'm2a') {
+    if (frame.withinTranslations) {
+      langView.value = { path, targetCollection: frame.targetCollection };
+      return;
+    }
+    finish(
+      buildTemplateToken({
+        mode: 'm2a-item',
+        fieldKey: props.context.fieldKey,
+        targetCollection: frame.targetCollection,
+        path,
+      })
+    );
+  } else {
+    finish(buildTemplateToken({ mode: 'relative', path }));
+  }
+}
+
+function pickLanguage(code: string | null) {
+  if (!langView.value || props.context.mode !== 'm2a') return;
+  finish(
+    buildTemplateToken({
+      mode: 'm2a-item',
+      fieldKey: props.context.fieldKey,
+      targetCollection: langView.value.targetCollection,
+      path: langView.value.path,
+      language: code,
+    })
+  );
+}
+
+function emitDiscriminator() {
+  if (props.context.mode !== 'm2a') return;
+  finish(buildTemplateToken({ mode: 'm2a-collection', fieldKey: props.context.fieldKey }));
+}
+
+function goBack() {
+  if (langView.value) {
+    langView.value = null;
+    return;
+  }
+  if (stack.value.length > 0) stack.value.pop();
+}
+
+function finish(token: string) {
+  emit('select', token);
+  open.value = false;
+}
+</script>
+
+<style scoped>
+.insert-field {
+  --v-icon-color: var(--foreground-subdued);
+  --v-icon-color-hover: var(--primary);
+  cursor: pointer;
+}
+</style>

--- a/src/composables/api.ts
+++ b/src/composables/api.ts
@@ -100,8 +100,14 @@ export function useTableApi() {
         if (filter) params.filter = filter;
         if (search) params.search = search;
         const response = await api.get(`/items/${collection}`, { params });
-        // Directus returns countDistinct under data[0].countDistinct.<fieldName>
-        const count = Number(response.data?.data?.[0]?.countDistinct?.[primaryKeyField] ?? 0);
+        // Directus returns countDistinct under data[0].countDistinct.<fieldName>.
+        // Guard the shape: on an unexpected (but non-throwing) response, fall
+        // through to the count(*) path instead of silently reporting 0.
+        const raw = response.data?.data?.[0]?.countDistinct?.[primaryKeyField];
+        const count = Number(raw);
+        if (raw == null || !Number.isFinite(count)) {
+          throw new Error('unexpected countDistinct response shape');
+        }
         filterCount.value = count;
         totalCount.value = count;
         return count;

--- a/src/composables/api.ts
+++ b/src/composables/api.ts
@@ -1,6 +1,7 @@
 import { ref, computed } from 'vue';
 import { useApi } from '@directus/extensions-sdk';
 import type { Item, Filter } from '@directus/types';
+import { filterUsesSome } from '../utils/filterUsesSome';
 
 export interface ApiOptions {
   collection: string;
@@ -78,12 +79,37 @@ export function useTableApi() {
    * `aggregate[countDistinct]=<pk>` both 403 when the user lacks PK access.
    * Returns the previous count on failure so a transient aggregate error
    * doesn't reset pagination to zero.
+   *
+   * Exception: when `primaryKeyField` is provided and the filter contains a
+   * `_some` operator (to-many join), `COUNT(*)` counts the join product instead
+   * of distinct parent rows — e.g. 1 item with 4 matching translations returns
+   * 4.  In that case we attempt `countDistinct(<pk>)` first and fall back to
+   * `count(*)` when it 403s (permission-denied on PK).
    */
   async function fetchItemCount(
     collection: string,
     filter?: Filter,
-    search?: string
+    search?: string,
+    primaryKeyField?: string
   ): Promise<number> {
+    // Use countDistinct when the filter crosses a to-many boundary (_some) and
+    // the caller supplied the PK field name.  Fall back to count(*) on error.
+    if (primaryKeyField && filter && filterUsesSome(filter)) {
+      try {
+        const params: any = { aggregate: { countDistinct: primaryKeyField } };
+        if (filter) params.filter = filter;
+        if (search) params.search = search;
+        const response = await api.get(`/items/${collection}`, { params });
+        // Directus returns countDistinct under data[0].countDistinct.<fieldName>
+        const count = Number(response.data?.data?.[0]?.countDistinct?.[primaryKeyField] ?? 0);
+        filterCount.value = count;
+        totalCount.value = count;
+        return count;
+      } catch {
+        // 403 or other error — fall through to the permissive count(*) path.
+      }
+    }
+
     try {
       const params: any = { aggregate: { count: '*' } };
       if (filter) params.filter = filter;

--- a/src/composables/useAliasFields.ts
+++ b/src/composables/useAliasFields.ts
@@ -131,6 +131,9 @@ export function useAliasFields(
     const aliasInfo = Object.values(aliasedFields.value).find((field) => field.key === key);
 
     // Skip any nested fields prefixed with $ as they dont exist. ($thumbnail as an example)
+    // NOTE: deliberately NOT splitPathSegments (resolveRelationalPath.ts) — this
+    // normalizes a lookup key for `get(item, key)` (no trim, empty segments kept,
+    // string result), it does not tokenize a schema walk.
     key = key.includes('.')
       ? key
           .split('.')

--- a/src/composables/useExistingLanguageDetection.ts
+++ b/src/composables/useExistingLanguageDetection.ts
@@ -1,5 +1,6 @@
 import { computed, type Ref } from 'vue';
 import type { Language } from '../types/table.types';
+import { splitLanguageSuffix, stripLanguageSuffix } from '../utils/displayHeuristics';
 
 /**
  * Composable for detecting existing languages in translation fields
@@ -19,8 +20,8 @@ export function useExistingLanguageDetection(
 
     return currentFields.value
       .filter((field) => field.startsWith(baseFieldKey + ':'))
-      .map((field) => field.split(':')[1])
-      .filter(Boolean); // Remove any undefined values
+      .map((field) => splitLanguageSuffix(field).language)
+      .filter(Boolean) as string[]; // Remove any null values
   }
 
   /**
@@ -60,10 +61,7 @@ export function useExistingLanguageDetection(
    * @returns Base field key (e.g., "translations.description")
    */
   function getBaseFieldKey(fieldKey: string): string {
-    if (fieldKey.includes(':')) {
-      return fieldKey.split(':')[0];
-    }
-    return fieldKey;
+    return stripLanguageSuffix(fieldKey);
   }
 
   /**

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -5,12 +5,7 @@
     <div class="table-toolbar" v-if="showToolbar">
       <div class="toolbar-content">
         <div class="search-input">
-          <v-input
-            v-model="searchQuery"
-            type="search"
-            :placeholder="t('search_items')"
-            @input="onSearchInput"
-          >
+          <v-input v-model="searchQuery" type="search" :placeholder="t('search_items')">
             <template #prepend>
               <v-icon name="search" />
             </template>
@@ -308,6 +303,7 @@ import {
 import { sanitizeFilter } from './utils/sanitizeFilter';
 import { buildNestedM2ADeep } from './utils/buildNestedM2ADeep';
 import { createDescribeHop } from './utils/describeHop';
+import { createCoalescedRunner } from './utils/coalesce';
 import { PER_PAGE_OPTIONS } from './constants/pagination';
 import { DEFAULT_LANGUAGES } from './constants/languages';
 import EditableCellRelational from './components/EditableCellRelational.vue';
@@ -327,8 +323,6 @@ const props = defineProps<{
   search?: string;
   readonly?: boolean;
   resetPreset?: () => void;
-  resetPresetAndRefresh?: () => void;
-  refresh?: () => void;
   clearFilters?: () => void;
 }>();
 
@@ -336,7 +330,7 @@ const emit = defineEmits<{
   'update:selection': [value: (string | number)[]];
   'update:layoutOptions': [value: LayoutOptions];
   'update:layoutQuery': [value: LayoutQuery];
-  'update:search': [value: string];
+  'update:search': [value: string | null];
   'update:filter': [value: any];
 }>();
 
@@ -754,10 +748,38 @@ const editMode = computed({
   },
 });
 
-// Search
-const searchQuery = ref(search?.value || '');
+// Search — single internal source of truth, mirrored from the native
+// header search (props.search, persisted per preset by Directus core).
+//
+// Native → internal: fully supported. collection.vue binds `:search` on
+// the layout wrapper and updates it per keystroke (no core debounce).
+//
+// Internal → native: NOT supported by the platform. The layout wrapper
+// (createLayoutWrapper, @directus/composables) only forwards
+// update:selection/layoutOptions/layoutQuery and silently swallows
+// `onUpdate:search`. The debounced emit below is a no-op today and kept
+// only for forward-compatibility; the equality guards make it loop-safe
+// should Directus ever whitelist `search` as a writable layout prop.
+const searchQuery = ref('');
+
+watch(
+  search,
+  (val) => {
+    // Native clear emits null; usePreset normalizes '' to null as well.
+    const incoming = val ?? '';
+    if (incoming !== searchQuery.value) {
+      searchQuery.value = incoming;
+    }
+  },
+  { immediate: true }
+);
+
 const onSearchInput = debounce((val: string) => {
-  emit('update:search', val);
+  // Mirror native semantics: empty input is represented as null.
+  const outgoing = val.trim() === '' ? null : val;
+  if ((search?.value ?? null) !== outgoing) {
+    emit('update:search', outgoing);
+  }
 }, 300);
 
 // Computed search filter
@@ -883,25 +905,13 @@ async function handleQuickFilterSaved(event: any) {
   }
 }
 
-// Issue #48: when columnDisplays change in options.vue (sibling slot), the prop
-// round-trip through the parent layout takes a few ticks. flush: 'post' makes
-// the watcher run after the DOM update so aliasedFields has fully settled
-// before we refetch.
-watch(
-  () => (layoutOptions.value as any)?.columnDisplays,
-  () => {
-    getItems();
-  },
-  { deep: true, flush: 'post' }
-);
-
 // Setup event listeners on mount
 onMounted(() => {
   // Load presets from layoutOptions (no localStorage needed)
   loadPresets();
 
   // Load initial items
-  getItems();
+  scheduleGetItems();
 
   // Listen for save events from actions
   window.addEventListener('quick-filter-saved', handleQuickFilterSaved);
@@ -1007,7 +1017,7 @@ async function getItems() {
         alias: aliasQuery.value || undefined,
       }),
       tableApi
-        .fetchItemCount(collection.value, combinedFilter.value, searchQuery.value || undefined)
+        .fetchItemCount(collection.value, combinedFilter.value, undefined, getPrimaryKeyFieldName())
         .catch(() => undefined),
     ]);
     items.value = itemsResult?.data || [];
@@ -1016,41 +1026,47 @@ async function getItems() {
   }
 }
 
+// Every refetch funnels through ONE runner: same-tick watcher storms collapse
+// into one execution, and overlapping executions are serialized with a single
+// trailing re-run (prevents an older response overwriting newer rows).
+// Force-refresh paths (events, auto-save, manual-sort recovery) call this
+// directly and therefore bypass the fingerprint dedupe on purpose: same
+// params, but server data changed.
+const scheduleGetItems = createCoalescedRunner(getItems);
+
 // Create a wrapper function for getItems
 async function refreshItems() {
-  await getItems();
+  await scheduleGetItems();
 }
 
-// Watch for refresh prop calls
-watch(
-  () => props.refresh,
-  (newVal) => {
-    if (newVal) {
-      refreshItems();
-    }
-  }
+// Refetch when the EFFECTIVE query changes. A string fingerprint makes Vue
+// dedupe by content: the upstream computeds rebuild arrays/objects with fresh
+// identity on every recompute (columnDisplaysRef -> aliasedFields ->
+// fieldsWithRelational), which used to re-fire this watcher with identical
+// parameters (e.g. three identical request pairs on bookmark load, and a
+// refetch on every layoutOptions write). Every fetch parameter getItems
+// reads is part of the fingerprint, so the watcher fires exactly when the
+// effective request changes. (searchQuery needs no own key: it only reaches
+// the request through combinedFilter.)
+const queryFingerprint = computed(() =>
+  JSON.stringify({
+    collection: collection.value,
+    fields: fieldsWithRelational.value,
+    filter: combinedFilter.value ?? null,
+    sort: sort.value,
+    page: page.value,
+    limit: limit.value,
+    deep: deep.value ?? null,
+    alias: aliasQuery.value ?? null,
+  })
 );
 
-// Watch for query parameter changes
-watch(
-  [combinedFilter, sort, page, limit, fieldsWithRelational],
-  () => {
-    // Don't refetch during manual sorting
-    if (!isManualSorting) {
-      getItems();
-    }
-  },
-  { deep: true }
-);
-
-watch(
-  () => props.resetPresetAndRefresh,
-  (newVal) => {
-    if (newVal) {
-      refreshItems();
-    }
+watch(queryFingerprint, () => {
+  // Don't refetch during manual sorting (same guard as before)
+  if (!isManualSorting) {
+    scheduleGetItems();
   }
-);
+});
 
 // Handle select all toggle
 function onToggleSelectAll() {
@@ -1072,7 +1088,7 @@ const { edits, savingCells, updateFieldValue, autoSaveEdits } = useTableEdits(
   collection,
   computed(() => primaryKeyField?.value || (primaryKeyField as any) || undefined),
   items,
-  getItems,
+  scheduleGetItems,
   translationConfig.value.languageCodeField
 );
 
@@ -1263,7 +1279,7 @@ async function handleManualSort({ item, to }: { item: any; to: any }) {
     });
   } catch (error: any) {
     // Refresh items to restore correct order on error
-    await getItems();
+    await scheduleGetItems();
 
     notificationsStore.add({
       title: t('error_moving_item'),
@@ -1311,30 +1327,38 @@ watch(searchQuery, (val) => {
 // Handle refresh event from actions component (for duplicate)
 function handleItemsDuplicated() {
   // Refresh the items list
-  getItems();
+  scheduleGetItems();
   // Clear selection after successful duplication
   selection.value = [];
 }
 
-// Setup event listeners for cross-component communication
+// Setup event listeners for cross-component communication.
+// Named handlers so onUnmounted removes the SAME references it registered
+// (the previous inline arrows made the removals silent no-ops).
+function handleItemsDeletedEvent() {
+  refreshItems();
+}
+
+function handleRefreshCollectionEvent(event: any) {
+  if (event.detail?.collection === collection.value) {
+    refreshItems();
+  }
+}
+
 onMounted(() => {
   window.addEventListener('directus-items-duplicated', handleItemsDuplicated);
 
   // Listen for Directus core delete events
-  window.addEventListener('items-deleted', () => refreshItems());
+  window.addEventListener('items-deleted', handleItemsDeletedEvent);
 
   // Listen for collection refresh events
-  window.addEventListener('refresh-collection', (event: any) => {
-    if (event.detail?.collection === collection.value) {
-      refreshItems();
-    }
-  });
+  window.addEventListener('refresh-collection', handleRefreshCollectionEvent);
 });
 
 onUnmounted(() => {
   window.removeEventListener('directus-items-duplicated', handleItemsDuplicated);
-  window.removeEventListener('items-deleted', refreshItems);
-  window.removeEventListener('refresh-collection', refreshItems);
+  window.removeEventListener('items-deleted', handleItemsDeletedEvent);
+  window.removeEventListener('refresh-collection', handleRefreshCollectionEvent);
 });
 </script>
 

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -306,6 +306,8 @@ import {
   getTranslationLanguageFieldPath,
 } from './composables/useTranslationConfig';
 import { sanitizeFilter } from './utils/sanitizeFilter';
+import { buildNestedM2ADeep } from './utils/buildNestedM2ADeep';
+import { createDescribeHop } from './utils/describeHop';
 import { PER_PAGE_OPTIONS } from './constants/pagination';
 import { DEFAULT_LANGUAGES } from './constants/languages';
 import EditableCellRelational from './components/EditableCellRelational.vue';
@@ -819,6 +821,20 @@ const deep = computed(() => {
       }
     }
   });
+
+  // Nested to-many relations inside expanded M2A item paths (e.g.
+  // treatment.item:service.translations) are not covered by the first-level
+  // entries above and would be capped at the server's default page size.
+  const nestedM2ADeep = buildNestedM2ADeep(
+    fieldsWithRelational.value,
+    createDescribeHop(fieldsStore, relationsStore)
+  );
+  for (const [fieldKey, scopes] of Object.entries(nestedM2ADeep)) {
+    deepFields[fieldKey] = {
+      ...(deepFields[fieldKey] ?? { _fields: ['*'], _limit: -1 }),
+      ...scopes,
+    };
+  }
 
   return Object.keys(deepFields).length > 0 ? deepFields : undefined;
 });

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -284,6 +284,7 @@ import { useStores, useCollection, useSync, useApi } from '@directus/extensions-
 import { formatTitle } from '@directus/format-title';
 import { getDefaultDisplayForType } from './utils/getDefaultDisplayForType';
 import { filterValidFields, filterValidColumnDisplays } from './utils/fieldValidity';
+import { splitLanguageSuffix, stripLanguageSuffix } from './utils/displayHeuristics';
 import { useTableApi } from './composables/api';
 import { useAliasFields } from './composables/useAliasFields';
 import { useLanguageSelector } from './composables/useLanguageSelector';
@@ -296,12 +297,14 @@ import { usePermissions } from './composables/usePermissions';
 import { useTranslationLanguages } from './composables/useTranslationLanguages';
 import { getTranslationFieldMetadata } from './utils/resolveTranslationsCollection';
 import { buildSearchFilter } from './utils/buildSearchFilter';
+import { normalizeIncomingSearch, normalizeOutgoingSearch } from './utils/searchSync';
 import {
   useTranslationConfig,
   getTranslationLanguageFieldPath,
 } from './composables/useTranslationConfig';
 import { sanitizeFilter } from './utils/sanitizeFilter';
-import { buildNestedM2ADeep } from './utils/buildNestedM2ADeep';
+import { buildNestedM2ADeep, mergeNestedM2ADeep } from './utils/buildNestedM2ADeep';
+import { buildQueryFingerprint } from './utils/buildQueryFingerprint';
 import { createDescribeHop } from './utils/describeHop';
 import { createCoalescedRunner } from './utils/coalesce';
 import { PER_PAGE_OPTIONS } from './constants/pagination';
@@ -482,13 +485,7 @@ const fields = computed({
 
 // Create a computed that strips language suffixes for aliasing
 const fieldsForAliasing = computed(() => {
-  return fields.value.map((field: string) => {
-    // Remove language suffix for alias fields
-    if (field.includes(':')) {
-      return field.split(':')[0];
-    }
-    return field;
-  });
+  return fields.value.map((field: string) => stripLanguageSuffix(field));
 });
 
 // Use alias fields for proper relational data handling.
@@ -579,28 +576,23 @@ const tableHeaders = computed(() => {
   const activeFields = fields.value
     .filter((rawKey: string) => {
       // Permission gate: drop language-suffixed translation fields the user can't read
-      if (rawKey.includes(':')) {
-        const [path, lang] = rawKey.split(':');
-        if (path.startsWith('translations.')) {
-          if (accessibleLanguages.length > 0 && !accessibleLanguages.includes(lang)) return false;
-          const subField = path.split('.').slice(1).join('.');
-          if (translationsCollection && !permissions.canRead(translationsCollection, subField))
-            return false;
-        }
+      const { path, language: lang } = splitLanguageSuffix(rawKey);
+      if (lang !== null && path.startsWith('translations.')) {
+        if (accessibleLanguages.length > 0 && !accessibleLanguages.includes(lang)) return false;
+        const subField = path.split('.').slice(1).join('.');
+        if (translationsCollection && !permissions.canRead(translationsCollection, subField))
+          return false;
       }
       // Permission gate: drop main-collection fields the user can't read
-      const rootField = rawKey.split(':')[0].split('.')[0];
+      const rootField = stripLanguageSuffix(rawKey).split('.')[0];
       if (!permissions.canRead(collection.value, rootField)) return false;
       return true;
     })
     .map((key: string) => {
       // Check if field has language suffix (e.g., "translations.description:de-DE")
-      let actualFieldKey = key;
-      let languageCode = null;
-
-      if (key.includes(':')) {
-        [actualFieldKey, languageCode] = key.split(':');
-      }
+      const split = splitLanguageSuffix(key);
+      let actualFieldKey = split.path;
+      let languageCode = split.language;
 
       let fieldData = fieldsStore.getField(collection.value, actualFieldKey);
 
@@ -646,7 +638,7 @@ const tableHeaders = computed(() => {
     }
 
     // Handle nested field paths like "translations.title"
-    const actualKey = field.key.includes(':') ? field.key.split(':')[0] : field.key;
+    const actualKey = stripLanguageSuffix(field.key);
     const fieldParts = actualKey.split('.');
     if (fieldParts.length > 1) {
       const fieldNames = fieldParts.map((fieldKey: string, index: number) => {
@@ -761,31 +753,54 @@ const editMode = computed({
 // only for forward-compatibility; the equality guards make it loop-safe
 // should Directus ever whitelist `search` as a writable layout prop.
 const searchQuery = ref('');
+// Debounced mirror that actually drives the request filter, so fast typing
+// fires one fetch after the user pauses instead of one per keystroke. Seeded
+// synchronously on preset hydration / native change (below) so a
+// preset-restored search already filters the FIRST load.
+const debouncedSearchQuery = ref('');
+const applyDebouncedSearch = debounce((val: string) => {
+  debouncedSearchQuery.value = val;
+}, 300);
 
+// Only the FIRST hydration must reflect into the request filter synchronously
+// (a preset-restored search has to filter the initial load — no unfiltered
+// flash). Every change after that — including typing in the native header —
+// flows through watch(searchQuery) and the 300ms debounce, so the native
+// search no longer fetches once per keystroke.
+let searchSeeded = false;
 watch(
   search,
   (val) => {
     // Native clear emits null; usePreset normalizes '' to null as well.
-    const incoming = val ?? '';
+    const incoming = normalizeIncomingSearch(val);
     if (incoming !== searchQuery.value) {
       searchQuery.value = incoming;
+      if (!searchSeeded) {
+        // First hydration: watch(searchQuery) isn't registered yet, so seed the
+        // debounced query directly and cancel any pending typing-debounce.
+        applyDebouncedSearch.cancel();
+        debouncedSearchQuery.value = incoming;
+      }
+      // Later changes: watch(searchQuery) schedules the debounced update.
     }
+    searchSeeded = true;
   },
   { immediate: true }
 );
 
 const onSearchInput = debounce((val: string) => {
   // Mirror native semantics: empty input is represented as null.
-  const outgoing = val.trim() === '' ? null : val;
+  const outgoing = normalizeOutgoingSearch(val);
   if ((search?.value ?? null) !== outgoing) {
     emit('update:search', outgoing);
   }
 }, 300);
 
-// Computed search filter
+// Computed search filter — reads the DEBOUNCED query so the request lags
+// typing by one debounce window instead of recomputing per keystroke.
 const searchFilter = computed(() =>
   buildSearchFilter({
-    query: searchQuery.value,
+    query: debouncedSearchQuery.value,
     visibleFields: fields.value,
     fieldsInCollection: fieldsInCollection.value,
     collection: collection.value,
@@ -800,7 +815,7 @@ const deep = computed(() => {
 
   fields.value.forEach((field: string) => {
     // Remove language suffix if present
-    const actualField = field.includes(':') ? field.split(':')[0] : field;
+    const actualField = stripLanguageSuffix(field);
 
     // Handle dot-notation relational fields (like "user_created.first_name")
     if (actualField.includes('.')) {
@@ -847,16 +862,10 @@ const deep = computed(() => {
   // Nested to-many relations inside expanded M2A item paths (e.g.
   // treatment.item:service.translations) are not covered by the first-level
   // entries above and would be capped at the server's default page size.
-  const nestedM2ADeep = buildNestedM2ADeep(
-    fieldsWithRelational.value,
-    createDescribeHop(fieldsStore, relationsStore)
+  mergeNestedM2ADeep(
+    deepFields,
+    buildNestedM2ADeep(fieldsWithRelational.value, createDescribeHop(fieldsStore, relationsStore))
   );
-  for (const [fieldKey, scopes] of Object.entries(nestedM2ADeep)) {
-    deepFields[fieldKey] = {
-      ...(deepFields[fieldKey] ?? { _fields: ['*'], _limit: -1 }),
-      ...scopes,
-    };
-  }
 
   return Object.keys(deepFields).length > 0 ? deepFields : undefined;
 });
@@ -1049,15 +1058,15 @@ async function refreshItems() {
 // effective request changes. (searchQuery needs no own key: it only reaches
 // the request through combinedFilter.)
 const queryFingerprint = computed(() =>
-  JSON.stringify({
+  buildQueryFingerprint({
     collection: collection.value,
     fields: fieldsWithRelational.value,
-    filter: combinedFilter.value ?? null,
+    filter: combinedFilter.value,
     sort: sort.value,
     page: page.value,
     limit: limit.value,
-    deep: deep.value ?? null,
-    alias: aliasQuery.value ?? null,
+    deep: deep.value,
+    alias: aliasQuery.value,
   })
 );
 
@@ -1321,6 +1330,7 @@ function handleTableRowClick({ item, event }: { item: Item; event: MouseEvent })
 
 // Watch for search changes
 watch(searchQuery, (val) => {
+  applyDebouncedSearch(val);
   onSearchInput(val);
 });
 

--- a/src/utils/adjustFieldsForDisplays.ts
+++ b/src/utils/adjustFieldsForDisplays.ts
@@ -16,6 +16,7 @@ import {
 import { resolveM2ARelation } from './resolveM2ARelation';
 import { createDescribeHop } from './describeHop';
 import { collectTranslationLanguagePaths } from './resolveRelationalPath';
+import { validateDeepPath } from './fieldValidity';
 
 /**
  * Helper function to get the related collection for a field
@@ -193,10 +194,15 @@ export function expandTokensThroughRelation(
         // (the renderer picks the translation language client-side).
         const { path } = splitLanguageSuffix(parsed.path);
         if (allowedCollections.length > 0 && !allowedCollections.includes(col)) continue;
-        // Only the first path segment is validated against the target — deep
-        // leaves are unvalidated, matching the M2M/M2O branches below.
-        const firstSegment = (path.split('.')[0] ?? '') as string;
-        if (!fieldsStore.getField(col, firstSegment)) continue;
+        // Every segment is walked against the schema; an invalid deep leaf
+        // would otherwise reach the API, 403, and blank the whole view.
+        const validation = validateDeepPath(col, path, fieldsStore, describeHop);
+        if (!validation.valid) {
+          console.warn(
+            `[super-layout-table] Dropped template field "item:${col}.${path}" (${validation.reason})`
+          );
+          continue;
+        }
         add(buildM2AFieldPath(fieldKey, itemField, col, path));
         // For a translations hop, also fetch its language column so the renderer
         // can match the active language instead of falling back to the first row.

--- a/src/utils/adjustFieldsForDisplays.ts
+++ b/src/utils/adjustFieldsForDisplays.ts
@@ -17,6 +17,7 @@ import { resolveM2ARelation } from './resolveM2ARelation';
 import { createDescribeHop } from './describeHop';
 import { collectTranslationLanguagePaths } from './resolveRelationalPath';
 import { validateDeepPath } from './fieldValidity';
+import { warnOnce } from './warnOnce';
 
 /**
  * Helper function to get the related collection for a field
@@ -145,8 +146,11 @@ function getDisplayFieldsForRelation(
 }
 
 // Expands template tokens to API field paths. For M2M, traverses
-// junction_field to reach the target collection; drops tokens that don't
-// exist on the target. Translations skip validation (varying schemas).
+// junction_field to reach the target collection. Every emitted path is
+// walked per segment against the schema (validateDeepPath); invalid tokens
+// are dropped with a deduplicated warning. Translations skip validation
+// (varying schemas; rows arrive via the deep parameter and the renderer
+// tolerates missing leaves).
 export function expandTokensThroughRelation(
   field: { meta?: { special?: string[] } } | null,
   fieldKey: string,
@@ -164,6 +168,10 @@ export function expandTokensThroughRelation(
     return tokens.map((tok) => `${fieldKey}.${tok}`);
   }
 
+  // Shared schema walker for every relational branch below. Creating it is a
+  // cheap closure factory; no store access happens until a hop is described.
+  const describeHop = createDescribeHop(fieldsStore, relationsStore);
+
   if (isM2A) {
     const m2a = resolveM2ARelation(parentCollection, fieldKey, relationsStore, fieldsStore);
     if (!m2a) return [];
@@ -175,7 +183,6 @@ export function expandTokensThroughRelation(
     const add = (path: string) => {
       if (!expanded.includes(path)) expanded.push(path);
     };
-    const describeHop = createDescribeHop(fieldsStore, relationsStore);
 
     for (const rawTok of tokens) {
       // The native picker prefixes relation tokens with the field key. A prefix
@@ -198,8 +205,8 @@ export function expandTokensThroughRelation(
         // would otherwise reach the API, 403, and blank the whole view.
         const validation = validateDeepPath(col, path, fieldsStore, describeHop);
         if (!validation.valid) {
-          console.warn(
-            `[super-layout-table] Dropped template field "item:${col}.${path}" (${validation.reason})`
+          warnOnce(
+            `[super-layout-table] Dropped template field "item:${col}.${path}" (M2A item: ${validation.reason})`
           );
           continue;
         }
@@ -216,18 +223,36 @@ export function expandTokensThroughRelation(
       if (!firstSegment) continue;
 
       if (hadPrefix) {
-        // Junction-level field (e.g. `treatment.sort`); validate against the
-        // junction so an unknown token never reaches the API and 403s.
-        if (junctionCollection && fieldsStore.getField(junctionCollection, firstSegment)) {
-          add(`${fieldKey}.${tok}`);
+        // Junction-level field (e.g. `treatment.sort`); every segment is
+        // walked against the junction schema so an unknown deep token never
+        // reaches the API and 403s.
+        if (junctionCollection) {
+          const junctionValidation = validateDeepPath(
+            junctionCollection,
+            tok,
+            fieldsStore,
+            describeHop
+          );
+          if (junctionValidation.valid) {
+            add(`${fieldKey}.${tok}`);
+          } else {
+            warnOnce(
+              `[super-layout-table] Dropped template field "${rawTok}" (M2A junction "${junctionCollection}": ${junctionValidation.reason})`
+            );
+          }
         }
         continue;
       }
 
       // Bare token → parent-level field (e.g. `code`), fetched at the top level.
-      // Validated against the parent so a stray token is dropped, not 403'd.
-      if (fieldsStore.getField(parentCollection, firstSegment)) {
+      // Walked per segment against the parent so a stray token is dropped, not 403'd.
+      const parentValidation = validateDeepPath(parentCollection, tok, fieldsStore, describeHop);
+      if (parentValidation.valid) {
         add(tok);
+      } else {
+        warnOnce(
+          `[super-layout-table] Dropped template field "${tok}" (M2A parent "${parentCollection}": ${parentValidation.reason})`
+        );
       }
     }
     return expanded;
@@ -252,8 +277,20 @@ export function expandTokensThroughRelation(
       // so we don't double-prefix.
       const tokWithoutJunctionPrefix = parts[0] === junctionField ? parts.slice(1).join('.') : tok;
       if (!tokWithoutJunctionPrefix) continue;
-      const firstSegment = tokWithoutJunctionPrefix.split('.')[0]!;
-      if (!fieldsStore.getField(targetCollection, firstSegment)) continue;
+      // Every segment is walked against the target schema; an invalid deep
+      // leaf would otherwise reach the API, 403, and blank the whole view.
+      const validation = validateDeepPath(
+        targetCollection,
+        tokWithoutJunctionPrefix,
+        fieldsStore,
+        describeHop
+      );
+      if (!validation.valid) {
+        warnOnce(
+          `[super-layout-table] Dropped template field "${tok}" (M2M target "${targetCollection}": ${validation.reason})`
+        );
+        continue;
+      }
       expanded.push(`${fieldKey}.${junctionField}.${tokWithoutJunctionPrefix}`);
     }
     return expanded;
@@ -272,8 +309,15 @@ export function expandTokensThroughRelation(
 
   const expanded: string[] = [];
   for (const tok of tokens) {
-    const firstSegment = tok.includes('.') ? (tok.split('.')[0] as string) : tok;
-    if (!fieldsStore.getField(target, firstSegment)) continue;
+    // Every segment is walked against the related collection; an invalid deep
+    // leaf would otherwise reach the API, 403, and blank the whole view.
+    const validation = validateDeepPath(target, tok, fieldsStore, describeHop);
+    if (!validation.valid) {
+      warnOnce(
+        `[super-layout-table] Dropped template field "${tok}" (relation target "${target}": ${validation.reason})`
+      );
+      continue;
+    }
     expanded.push(`${fieldKey}.${tok}`);
   }
   return expanded;

--- a/src/utils/adjustFieldsForDisplays.ts
+++ b/src/utils/adjustFieldsForDisplays.ts
@@ -10,9 +10,12 @@ import {
   buildM2AFieldPath,
   isM2APrefix,
   stripM2AFieldPrefix,
+  splitLanguageSuffix,
   M2A_COLLECTION_TOKEN,
 } from './displayHeuristics';
 import { resolveM2ARelation } from './resolveM2ARelation';
+import { createDescribeHop } from './describeHop';
+import { collectTranslationLanguagePaths } from './resolveRelationalPath';
 
 /**
  * Helper function to get the related collection for a field
@@ -171,6 +174,7 @@ export function expandTokensThroughRelation(
     const add = (path: string) => {
       if (!expanded.includes(path)) expanded.push(path);
     };
+    const describeHop = createDescribeHop(fieldsStore, relationsStore);
 
     for (const rawTok of tokens) {
       // The native picker prefixes relation tokens with the field key. A prefix
@@ -184,13 +188,21 @@ export function expandTokensThroughRelation(
       // Per-collection item token: "item:collection.path".
       const parsed = parseM2AToken(tok);
       if (parsed && isM2APrefix(parsed.prefix, fieldKey, itemField)) {
-        const { collection: col, path } = parsed;
+        const { collection: col } = parsed;
+        // Drop the extension-only `:lang` suffix; the API path must not carry it
+        // (the renderer picks the translation language client-side).
+        const { path } = splitLanguageSuffix(parsed.path);
         if (allowedCollections.length > 0 && !allowedCollections.includes(col)) continue;
         // Only the first path segment is validated against the target — deep
         // leaves are unvalidated, matching the M2M/M2O branches below.
         const firstSegment = (path.split('.')[0] ?? '') as string;
         if (!fieldsStore.getField(col, firstSegment)) continue;
         add(buildM2AFieldPath(fieldKey, itemField, col, path));
+        // For a translations hop, also fetch its language column so the renderer
+        // can match the active language instead of falling back to the first row.
+        for (const langPath of collectTranslationLanguagePaths(path, col, describeHop)) {
+          add(buildM2AFieldPath(fieldKey, itemField, col, langPath));
+        }
         continue;
       }
 

--- a/src/utils/adjustFieldsForDisplays.ts
+++ b/src/utils/adjustFieldsForDisplays.ts
@@ -11,6 +11,7 @@ import {
   isM2APrefix,
   stripM2AFieldPrefix,
   splitLanguageSuffix,
+  stripLanguageSuffix,
   M2A_COLLECTION_TOKEN,
 } from './displayHeuristics';
 import { resolveM2ARelation } from './resolveM2ARelation';
@@ -368,7 +369,7 @@ export function adjustFieldsForDisplays(
       // (translations.title), but layoutQuery.fields entries can carry a language
       // suffix (translations.title:de-DE). Strip the suffix before lookup so a
       // single override applies to every language column for the same root field.
-      const storageKey = fieldKey.includes(':') ? fieldKey.split(':')[0] : fieldKey;
+      const storageKey = stripLanguageSuffix(fieldKey);
       const override = overrides[storageKey];
       if (override?.template) {
         const tokens = parseTemplateTokens(override.template);

--- a/src/utils/buildM2ASegments.ts
+++ b/src/utils/buildM2ASegments.ts
@@ -1,4 +1,4 @@
-import { renderM2ATemplate } from './renderM2ATemplate';
+import { renderM2ATemplate, type RenderM2AOptions } from './renderM2ATemplate';
 
 /**
  * One rendered M2A junction row: either resolved template text, or a `block`
@@ -30,7 +30,8 @@ export function buildM2ASegments(
   discriminator: string,
   fieldName: string,
   parentRow: Record<string, any> | null | undefined,
-  canRead: (collection: string) => boolean
+  canRead: (collection: string) => boolean,
+  renderOpts?: RenderM2AOptions
 ): M2ASegment[] {
   if (!Array.isArray(rows) || rows.length === 0) return [];
 
@@ -52,7 +53,8 @@ export function buildM2ASegments(
       itemField,
       discriminator,
       fieldName,
-      parentRow
+      parentRow,
+      renderOpts
     ).trim();
     if (text && text !== '—') segments.push({ text });
   }

--- a/src/utils/buildNestedM2ADeep.ts
+++ b/src/utils/buildNestedM2ADeep.ts
@@ -1,4 +1,4 @@
-import type { DescribeHop } from './resolveRelationalPath';
+import { splitPathSegments, type DescribeHop } from './resolveRelationalPath';
 
 /** Hop kinds whose value is an array the server pages with its default limit. */
 const TO_MANY_KINDS = new Set(['o2m', 'm2m', 'm2a', 'files', 'translations']);
@@ -33,10 +33,7 @@ export function buildNestedM2ADeep(
     if (!match) continue;
     const fieldKey = match[1]!;
     const itemScope = `${match[2]!}:${match[3]!}`;
-    const segments = match[4]!
-      .split('.')
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0 && !s.startsWith('$'));
+    const segments = splitPathSegments(match[4]!);
 
     let collection: string | null = match[3]!;
     for (let i = 0; i < segments.length && collection; i++) {

--- a/src/utils/buildNestedM2ADeep.ts
+++ b/src/utils/buildNestedM2ADeep.ts
@@ -1,0 +1,56 @@
+import type { DescribeHop } from './resolveRelationalPath';
+
+/** Hop kinds whose value is an array the server pages with its default limit. */
+const TO_MANY_KINDS = new Set(['o2m', 'm2m', 'm2a', 'files', 'translations']);
+
+/**
+ * Derive nested `deep` entries for expanded M2A item paths.
+ *
+ * `deep[<field>][_limit]=-1` only unbounds the junction rows; a to-many
+ * relation *inside* the polymorphic item (e.g.
+ * `treatment.item:service.translations.label`) stays capped at the server's
+ * default page size unless it gets its own limit. For every to-many hop
+ * crossed by such a path this returns the matching nested structure, e.g.
+ * `{ treatment: { 'item:service': { translations: { _limit: -1 } } } }`,
+ * ready to merge into the layout's deep object.
+ *
+ * The `item:<collection>` scope key is matched literally by the API's deep
+ * parser (api/src/database/get-ast-from-query/lib/parse-fields.ts, unchanged
+ * v9 → main) and recurses — verified live on 11.11.0 at depth 2. It is
+ * undocumented upstream, so re-verify on major Directus upgrades. Emit
+ * `_limit` ONLY here: nested deep with dynamic-variable filters is unreliable
+ * on 11.x (unawaited sanitizeDeep recursion, directus/directus#27676,
+ * fixed in v12).
+ */
+export function buildNestedM2ADeep(
+  expandedFields: readonly string[],
+  describeHop: DescribeHop
+): Record<string, Record<string, any>> {
+  const result: Record<string, Record<string, any>> = {};
+
+  for (const fullPath of expandedFields) {
+    const match = /^([^.:]+)\.([^.:]+):([^.:]+)\.(.+)$/.exec(fullPath);
+    if (!match) continue;
+    const fieldKey = match[1]!;
+    const itemScope = `${match[2]!}:${match[3]!}`;
+    const segments = match[4]!
+      .split('.')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0 && !s.startsWith('$'));
+
+    let collection: string | null = match[3]!;
+    for (let i = 0; i < segments.length && collection; i++) {
+      const segment = segments[i]!;
+      const hop = describeHop(collection, segment);
+      if (TO_MANY_KINDS.has(hop.kind)) {
+        const fieldEntry = (result[fieldKey] ??= {});
+        let node: Record<string, any> = (fieldEntry[itemScope] ??= {});
+        for (let j = 0; j < i; j++) node = node[segments[j]!] ??= {};
+        node[segment] = { ...(node[segment] ?? {}), _limit: -1 };
+      }
+      collection = hop.relatedCollection ?? null;
+    }
+  }
+
+  return result;
+}

--- a/src/utils/buildNestedM2ADeep.ts
+++ b/src/utils/buildNestedM2ADeep.ts
@@ -15,12 +15,13 @@ const TO_MANY_KINDS = new Set(['o2m', 'm2m', 'm2a', 'files', 'translations']);
  * ready to merge into the layout's deep object.
  *
  * The `item:<collection>` scope key is matched literally by the API's deep
- * parser (api/src/database/get-ast-from-query/lib/parse-fields.ts, unchanged
- * v9 → main) and recurses — verified live on 11.11.0 at depth 2. It is
- * undocumented upstream, so re-verify on major Directus upgrades. Emit
- * `_limit` ONLY here: nested deep with dynamic-variable filters is unreliable
- * on 11.x (unawaited sanitizeDeep recursion, directus/directus#27676,
- * fixed in v12).
+ * parser: api/src/database/get-ast-from-query/lib/parse-fields.ts looks the
+ * scoped subtree up by `${fieldKey}:${relatedCollection}` (v11.11.0 lines
+ * 222 + 228) and feeds it back into the recursive parser — unchanged v9 →
+ * main, verified live on 11.11.0 at depth 2. It is undocumented upstream, so
+ * re-verify on major Directus upgrades. Emit `_limit` ONLY here: nested deep
+ * with dynamic-variable filters is unreliable on 11.x (unawaited
+ * sanitizeDeep recursion, directus/directus#27676, fixed in v12).
  */
 export function buildNestedM2ADeep(
   expandedFields: readonly string[],
@@ -50,4 +51,24 @@ export function buildNestedM2ADeep(
   }
 
   return result;
+}
+
+/**
+ * Merge nested M2A deep entries (from `buildNestedM2ADeep`) into an existing
+ * `deep` object: preserves each field's existing `_fields`/`_limit` and adds
+ * the `item:<collection>` scope keys. A field absent from `deepFields` gets a
+ * sensible M2A default (`{ _fields: ['*'], _limit: -1 }`). Mutates and returns
+ * `deepFields`.
+ */
+export function mergeNestedM2ADeep(
+  deepFields: Record<string, any>,
+  nested: Record<string, Record<string, any>>
+): Record<string, any> {
+  for (const [fieldKey, scopes] of Object.entries(nested)) {
+    deepFields[fieldKey] = {
+      ...(deepFields[fieldKey] ?? { _fields: ['*'], _limit: -1 }),
+      ...scopes,
+    };
+  }
+  return deepFields;
 }

--- a/src/utils/buildQueryFingerprint.ts
+++ b/src/utils/buildQueryFingerprint.ts
@@ -1,0 +1,30 @@
+/**
+ * Stable string fingerprint of every parameter that affects the items request.
+ * The query watcher dedupes on this string, so it must include EXACTLY what
+ * `getItems` reads — extracted here so a test pins that set (dropping a key
+ * would silently suppress a needed refetch). Key order is fixed for stable
+ * output across evaluations.
+ */
+export interface QueryFingerprintInput {
+  collection: string | null;
+  fields: readonly string[];
+  filter: unknown;
+  sort: readonly string[] | null | undefined;
+  page: number;
+  limit: number;
+  deep: unknown;
+  alias: unknown;
+}
+
+export function buildQueryFingerprint(input: QueryFingerprintInput): string {
+  return JSON.stringify({
+    collection: input.collection,
+    fields: input.fields,
+    filter: input.filter ?? null,
+    sort: input.sort,
+    page: input.page,
+    limit: input.limit,
+    deep: input.deep ?? null,
+    alias: input.alias ?? null,
+  });
+}

--- a/src/utils/buildTemplateToken.ts
+++ b/src/utils/buildTemplateToken.ts
@@ -1,0 +1,30 @@
+/**
+ * Build a `{{…}}` template token for the Display Template editor's field picker.
+ * The form depends on the column's relation type (see the design spec):
+ * M2A tokens are field-key-prefixed and carry the `item:<collection>` scope
+ * (plus an optional `:lang` suffix on nested-translation paths); non-M2A
+ * relational tokens are written relative to the related collection.
+ */
+export type TemplateTokenContext =
+  | { mode: 'm2a-collection'; fieldKey: string }
+  | {
+      mode: 'm2a-item';
+      fieldKey: string;
+      targetCollection: string;
+      path: string;
+      language?: string | null;
+    }
+  | { mode: 'relative'; path: string };
+
+export function buildTemplateToken(ctx: TemplateTokenContext): string {
+  switch (ctx.mode) {
+    case 'm2a-collection':
+      return `{{${ctx.fieldKey}.collection}}`;
+    case 'm2a-item': {
+      const lang = ctx.language ? `:${ctx.language}` : '';
+      return `{{${ctx.fieldKey}.item:${ctx.targetCollection}.${ctx.path}${lang}}}`;
+    }
+    case 'relative':
+      return `{{${ctx.path}}}`;
+  }
+}

--- a/src/utils/coalesce.ts
+++ b/src/utils/coalesce.ts
@@ -1,0 +1,51 @@
+/**
+ * Collapses N triggers into a minimal number of executions of `fn`:
+ *
+ * - Triggers arriving while nothing is scheduled/running share ONE
+ *   microtask-deferred execution (same-tick coalescing). Vue runs pre-flush
+ *   watchers, component re-renders and post-flush watchers inside a single
+ *   scheduler microtask; a microtask queued from any of them executes after
+ *   that whole cycle, so one user action that fires several watchers (even
+ *   pre- AND post-flush) results in exactly one `fn` call.
+ * - Triggers arriving WHILE `fn` is executing set a re-run flag; exactly one
+ *   follow-up execution starts after the current one settles, no matter how
+ *   many triggers arrived in between (trailing-edge, single-flight).
+ * - `fn` must read its inputs at execution time (Vue `.value` reads); the
+ *   runner deliberately passes no arguments, so the final state always wins.
+ *
+ * Limitation by design: triggers in different macrotasks (e.g. network
+ * resolutions) are separate executions — content-level dedupe is the
+ * fingerprint watcher's job, not this runner's.
+ */
+export function createCoalescedRunner(fn: () => Promise<void> | void): () => Promise<void> {
+  let scheduled = false;
+  let running = false;
+  let rerunRequested = false;
+  let settled: Promise<void> = Promise.resolve();
+
+  async function execute(): Promise<void> {
+    scheduled = false;
+    running = true;
+    try {
+      do {
+        rerunRequested = false;
+        await fn();
+      } while (rerunRequested);
+    } finally {
+      running = false;
+    }
+  }
+
+  return function schedule(): Promise<void> {
+    if (running) {
+      rerunRequested = true;
+      return settled;
+    }
+    if (scheduled) {
+      return settled;
+    }
+    scheduled = true;
+    settled = Promise.resolve().then(execute);
+    return settled;
+  };
+}

--- a/src/utils/describeHop.ts
+++ b/src/utils/describeHop.ts
@@ -1,0 +1,81 @@
+import type { DescribeHop, HopInfo } from './resolveRelationalPath';
+
+/**
+ * Builds the schema-aware `describeHop` callback that `resolveRelationalPath`
+ * uses to interpret each path segment. Kept as a factory over store-like
+ * dependencies so the pure resolver stays testable and this glue stays thin.
+ */
+
+interface FieldsStoreLike {
+  getField: (
+    collection: string,
+    field: string
+  ) => { meta?: { special?: string[] | null } | null } | null;
+}
+
+interface RelationLike {
+  collection?: string;
+  field?: string;
+  related_collection?: string | null;
+  meta?: { one_field?: string | null; junction_field?: string | null } | null;
+}
+
+interface RelationsStoreLike {
+  getRelationsForField: (collection: string, field: string) => RelationLike[] | null | undefined;
+}
+
+export function createDescribeHop(
+  fieldsStore: FieldsStoreLike,
+  relationsStore: RelationsStoreLike
+): DescribeHop {
+  return (collection: string, field: string): HopInfo => {
+    let special: string[];
+    let relations: RelationLike[];
+    try {
+      special = fieldsStore.getField(collection, field)?.meta?.special ?? [];
+      relations = relationsStore.getRelationsForField(collection, field) ?? [];
+    } catch {
+      // Stores can throw during unloaded states (early app boot).
+      return { kind: 'scalar' };
+    }
+
+    // Translations: the parent→junction relation carries `one_field === field`
+    // and its `junction_field` is the language column (e.g. `languages_code`).
+    if (special.includes('translations')) {
+      const rel = relations.find((r) => r?.meta?.one_field === field) ?? relations[0];
+      return {
+        kind: 'translations',
+        relatedCollection: rel?.collection ?? null,
+        languageField: rel?.meta?.junction_field ?? null,
+      };
+    }
+
+    if (special.includes('m2a')) return { kind: 'm2a', relatedCollection: null };
+    if (special.includes('files')) return { kind: 'files', relatedCollection: 'directus_files' };
+
+    // M2O / single file: this collection owns the FK pointing at the related one.
+    const owned = relations.find(
+      (r) => r?.collection === collection && r?.field === field && r?.related_collection
+    );
+    if (
+      special.includes('m2o') ||
+      (owned && !special.includes('o2m') && !special.includes('m2m'))
+    ) {
+      const kind = special.includes('file') ? 'file' : 'm2o';
+      return { kind, relatedCollection: owned?.related_collection ?? null };
+    }
+    if (special.includes('file')) return { kind: 'file', relatedCollection: 'directus_files' };
+
+    // To-many: O2M / M2M. The related collection is the junction's own collection
+    // (the array elements); deeper traversal past the first element is best-effort.
+    if (special.includes('m2m') || special.includes('o2m')) {
+      const rel = relations[0];
+      return {
+        kind: special.includes('m2m') ? 'm2m' : 'o2m',
+        relatedCollection: rel?.collection ?? null,
+      };
+    }
+
+    return { kind: 'scalar' };
+  };
+}

--- a/src/utils/describeHop.ts
+++ b/src/utils/describeHop.ts
@@ -36,6 +36,11 @@ export function createDescribeHop(
       relations = relationsStore.getRelationsForField(collection, field) ?? [];
     } catch {
       // Stores can throw during unloaded states (early app boot).
+      // Mapped to 'scalar' deliberately: the renderer treats scalar/unknown
+      // identically (read & stop). Caveat: validateDeepPath rejects a
+      // mid-path 'scalar', so a relations-store-only throw can drop a valid
+      // path until stores hydrate (documented there). Pinned by
+      // describeHop.test.ts ('store throwing → scalar').
       return { kind: 'scalar' };
     }
 

--- a/src/utils/displayHeuristics.ts
+++ b/src/utils/displayHeuristics.ts
@@ -108,6 +108,16 @@ export function splitLanguageSuffix(path: string): { path: string; language: str
   return { path: path.slice(0, i), language: path.slice(i + 1) || null };
 }
 
+/**
+ * Strip an optional trailing `:language` suffix from a field key, returning
+ * just the path. Convenience wrapper over `splitLanguageSuffix(key).path` for
+ * the many "I only need the path" call sites (column keys carry at most one
+ * such suffix). A key without a suffix is returned unchanged.
+ */
+export function stripLanguageSuffix(key: string): string {
+  return splitLanguageSuffix(key).path;
+}
+
 interface RelationsStoreLike {
   getRelationsForField: (
     collection: string,

--- a/src/utils/displayHeuristics.ts
+++ b/src/utils/displayHeuristics.ts
@@ -96,6 +96,18 @@ export function stripM2AFieldPrefix(token: string, fieldName: string): string {
   return token.startsWith(prefix) ? token.slice(prefix.length) : token;
 }
 
+/**
+ * Split an optional `:language` suffix off an M2A item path. The suffix selects
+ * a translation row (e.g. `translations.label:de-DE`) and is an extension-side
+ * convention — it must be stripped before the path is sent to the API, and used
+ * by the renderer to pick the language. Returns `language: null` when absent.
+ */
+export function splitLanguageSuffix(path: string): { path: string; language: string | null } {
+  const i = path.lastIndexOf(':');
+  if (i < 0) return { path, language: null };
+  return { path: path.slice(0, i), language: path.slice(i + 1) || null };
+}
+
 interface RelationsStoreLike {
   getRelationsForField: (
     collection: string,

--- a/src/utils/fieldValidity.ts
+++ b/src/utils/fieldValidity.ts
@@ -7,7 +7,7 @@
  * preset — if the field is recreated later, the column/sort comes back.
  */
 
-import type { DescribeHop } from './resolveRelationalPath';
+import { splitPathSegments, type DescribeHop } from './resolveRelationalPath';
 
 interface FieldsStoreLike {
   getField: (collection: string | null, field: string) => unknown;
@@ -117,14 +117,14 @@ export function filterValidColumnDisplays<T>(
 }
 
 /**
- * Walk every segment of a relational deep path (as used by M2A
- * `item:collection.path` template tokens) against the schema. A path is only
- * sent to the API when each segment exists on its collection and every
- * intermediate segment is a relational hop we can follow — the API answers
- * 403 for unknown fields (deliberately, to avoid schema leaks), which would
- * blank the entire view. Native Directus does NOT validate template fields
- * (its adjust-fields-for-displays passes unknown keys through), so this is
- * deliberate hardening beyond native behavior.
+ * Walk every segment of a relational deep path (used by every relational
+ * template-token branch: M2A item/junction/parent, M2M, M2O/O2M/files)
+ * against the schema. A path is only sent to the API when each segment exists
+ * on its collection and every intermediate segment is a relational hop we can
+ * follow — the API answers 403 for unknown fields (deliberately, to avoid
+ * schema leaks), which would blank the entire view. Native Directus does NOT
+ * validate template fields (its adjust-fields-for-displays passes unknown keys
+ * through), so this is deliberate hardening beyond native behavior.
  *
  * Permissive where the schema cannot be walked further (hop with unknown
  * related collection, e.g. a nested M2A, or stores throwing during early
@@ -137,10 +137,7 @@ export function validateDeepPath(
   fieldsStore: { getField: (collection: string, field: string) => unknown },
   describeHop: DescribeHop
 ): { valid: boolean; reason?: string } {
-  const segments = path
-    .split('.')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0 && !s.startsWith('$'));
+  const segments = splitPathSegments(path);
   if (segments.length === 0) return { valid: false, reason: 'empty path' };
 
   let collection = startCollection;
@@ -153,6 +150,13 @@ export function validateDeepPath(
       if (i === segments.length - 1) break; // the leaf may be any existing field
       const hop = describeHop(collection, segment);
       if (hop.kind === 'scalar') {
+        // NOTE: describeHop also maps INTERNAL store throws to 'scalar'
+        // (see createDescribeHop). If only the relations store throws while
+        // the fields store answered (the getField above succeeded), this
+        // rejects a path we could not actually inspect. Accepted trade-off:
+        // the window is store-bootstrap only, the drop self-heals on the
+        // next recompute after hydration, and a dedicated 'unknown' hop kind
+        // would ripple through every HopKind consumer for an unobserved case.
         return { valid: false, reason: `"${collection}.${segment}" is not a relation` };
       }
       // `files` hides a junction level describeHop doesn't expose — like an

--- a/src/utils/fieldValidity.ts
+++ b/src/utils/fieldValidity.ts
@@ -8,6 +8,7 @@
  */
 
 import { splitPathSegments, type DescribeHop } from './resolveRelationalPath';
+import { stripLanguageSuffix } from './displayHeuristics';
 
 interface FieldsStoreLike {
   getField: (collection: string | null, field: string) => unknown;
@@ -28,10 +29,7 @@ function normalizeFieldKey(key: string, stripSortPrefix: boolean): string {
   if (stripSortPrefix && normalized.startsWith('-')) {
     normalized = normalized.substring(1);
   }
-  if (normalized.includes(':')) {
-    normalized = normalized.split(':')[0] ?? '';
-  }
-  return normalized;
+  return stripLanguageSuffix(normalized);
 }
 
 /**

--- a/src/utils/fieldValidity.ts
+++ b/src/utils/fieldValidity.ts
@@ -7,6 +7,8 @@
  * preset — if the field is recreated later, the column/sort comes back.
  */
 
+import type { DescribeHop } from './resolveRelationalPath';
+
 interface FieldsStoreLike {
   getField: (collection: string | null, field: string) => unknown;
 }
@@ -112,4 +114,54 @@ export function filterValidColumnDisplays<T>(
     }
   }
   return result;
+}
+
+/**
+ * Walk every segment of a relational deep path (as used by M2A
+ * `item:collection.path` template tokens) against the schema. A path is only
+ * sent to the API when each segment exists on its collection and every
+ * intermediate segment is a relational hop we can follow — the API answers
+ * 403 for unknown fields (deliberately, to avoid schema leaks), which would
+ * blank the entire view. Native Directus does NOT validate template fields
+ * (its adjust-fields-for-displays passes unknown keys through), so this is
+ * deliberate hardening beyond native behavior.
+ *
+ * Permissive where the schema cannot be walked further (hop with unknown
+ * related collection, e.g. a nested M2A, or stores throwing during early
+ * boot): the path is kept and the API stays the judge, preserving the
+ * previous behavior for shapes we cannot prove invalid.
+ */
+export function validateDeepPath(
+  startCollection: string,
+  path: string,
+  fieldsStore: { getField: (collection: string, field: string) => unknown },
+  describeHop: DescribeHop
+): { valid: boolean; reason?: string } {
+  const segments = path
+    .split('.')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !s.startsWith('$'));
+  if (segments.length === 0) return { valid: false, reason: 'empty path' };
+
+  let collection = startCollection;
+  try {
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i]!;
+      if (!fieldsStore.getField(collection, segment)) {
+        return { valid: false, reason: `unknown field "${collection}.${segment}"` };
+      }
+      if (i === segments.length - 1) break; // the leaf may be any existing field
+      const hop = describeHop(collection, segment);
+      if (hop.kind === 'scalar') {
+        return { valid: false, reason: `"${collection}.${segment}" is not a relation` };
+      }
+      // `files` hides a junction level describeHop doesn't expose — like an
+      // unknown related collection we stop walking and keep the path.
+      if (hop.kind === 'files' || !hop.relatedCollection) return { valid: true };
+      collection = hop.relatedCollection;
+    }
+  } catch {
+    return { valid: true };
+  }
+  return { valid: true };
 }

--- a/src/utils/filterUsesSome.ts
+++ b/src/utils/filterUsesSome.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns true when a Directus filter node traverses a to-many relation via
+ * `_some` — the case where `COUNT(*)` counts the join product instead of
+ * distinct items.
+ *
+ * Walks the full filter tree (arrays, plain objects) and checks every key
+ * against the literal string `_some`. Other operator names that start with
+ * `_some` (there are none in the current Directus schema, but guard against
+ * false positives) do NOT match because the check is an exact equality test.
+ */
+export function filterUsesSome(node: unknown): boolean {
+  if (Array.isArray(node)) return node.some(filterUsesSome);
+  if (node && typeof node === 'object') {
+    return Object.entries(node).some(([key, value]) => key === '_some' || filterUsesSome(value));
+  }
+  return false;
+}

--- a/src/utils/listPickerFields.ts
+++ b/src/utils/listPickerFields.ts
@@ -1,0 +1,72 @@
+import type { DescribeHop } from './resolveRelationalPath';
+
+export interface PickerEntry {
+  /** Field key on the current collection. */
+  field: string;
+  /** Display label (field name, falling back to the key). */
+  label: string;
+  /** True for to-one + translations hops the picker follows. */
+  drillable: boolean;
+  /** Collection to drill into (null for scalar leaves). */
+  relatedCollection: string | null;
+  /** True when this field is a `translations` relation (enables the language step). */
+  isTranslationsHop: boolean;
+}
+
+interface FieldLike {
+  field: string;
+  name?: string;
+}
+interface FieldsStoreLike {
+  getFieldsForCollection: (collection: string) => FieldLike[];
+}
+
+/** Hop kinds whose value is a single related row the picker drills into. */
+const TO_ONE = new Set(['m2o', 'file']);
+
+/**
+ * Build one menu level for `collection`: scalar fields become selectable leaves;
+ * to-one (m2o/file) and `translations` relations become drillable entries.
+ * Everything else (to-many relations, or any hop with no related collection) is
+ * omitted, so the picker can never produce a token the renderer won't resolve.
+ */
+export function listPickerFields(
+  collection: string,
+  describeHop: DescribeHop,
+  fieldsStore: FieldsStoreLike
+): PickerEntry[] {
+  const fields = fieldsStore.getFieldsForCollection(collection) ?? [];
+  const out: PickerEntry[] = [];
+  for (const f of fields) {
+    if (!f?.field || f.field.startsWith('$')) continue;
+    const label = f.name && f.name.length > 0 ? f.name : f.field;
+    const hop = describeHop(collection, f.field);
+    if (hop.kind === 'scalar') {
+      out.push({
+        field: f.field,
+        label,
+        drillable: false,
+        relatedCollection: null,
+        isTranslationsHop: false,
+      });
+    } else if (hop.kind === 'translations' && hop.relatedCollection) {
+      out.push({
+        field: f.field,
+        label,
+        drillable: true,
+        relatedCollection: hop.relatedCollection,
+        isTranslationsHop: true,
+      });
+    } else if (TO_ONE.has(hop.kind) && hop.relatedCollection) {
+      out.push({
+        field: f.field,
+        label,
+        drillable: true,
+        relatedCollection: hop.relatedCollection,
+        isTranslationsHop: false,
+      });
+    }
+    // to-many / unknown / no-related → omitted
+  }
+  return out;
+}

--- a/src/utils/renderM2ATemplate.ts
+++ b/src/utils/renderM2ATemplate.ts
@@ -7,6 +7,7 @@ import {
   M2A_COLLECTION_TOKEN,
 } from './displayHeuristics';
 import { resolveRelationalPath, type DescribeHop } from './resolveRelationalPath';
+import { stripHtml } from './stripHtml';
 
 export interface RenderM2AOptions {
   /** Schema-aware hop resolver; enables deep relational paths (e.g. nested translations). */
@@ -85,7 +86,8 @@ function getNestedValue(source: any, path: string): any {
   return get(source, cleaned);
 }
 
-/** Tokens render scalars only; objects/arrays collapse to '' to avoid "[object Object]". */
+/** Tokens render scalars only; objects/arrays collapse to '' to avoid "[object Object]".
+ *  HTML is stripped so rich-text values match the native formatted-value display. */
 function scalarOrEmpty(value: any): string {
-  return value != null && typeof value !== 'object' ? String(value) : '';
+  return value != null && typeof value !== 'object' ? stripHtml(value) : '';
 }

--- a/src/utils/renderM2ATemplate.ts
+++ b/src/utils/renderM2ATemplate.ts
@@ -3,8 +3,17 @@ import {
   parseM2AToken,
   isM2APrefix,
   stripM2AFieldPrefix,
+  splitLanguageSuffix,
   M2A_COLLECTION_TOKEN,
 } from './displayHeuristics';
+import { resolveRelationalPath, type DescribeHop } from './resolveRelationalPath';
+
+export interface RenderM2AOptions {
+  /** Schema-aware hop resolver; enables deep relational paths (e.g. nested translations). */
+  describeHop?: DescribeHop;
+  /** Fallback language when a token carries no `:lang` suffix. */
+  language?: string | null;
+}
 
 /**
  * Render one M2A junction row against a related-values template.
@@ -19,7 +28,8 @@ export function renderM2ATemplate(
   itemField: string,
   discriminator: string,
   fieldName: string,
-  parentRow?: Record<string, any> | null
+  parentRow?: Record<string, any> | null,
+  opts?: RenderM2AOptions
 ): string {
   if (!row || typeof row !== 'object') return '—';
   const rowCollection = row[discriminator];
@@ -43,7 +53,14 @@ export function renderM2ATemplate(
     const parsed = parseM2AToken(token);
     if (parsed && isM2APrefix(parsed.prefix, fieldName, itemField)) {
       if (parsed.collection !== rowCollection) return '';
-      return scalarOrEmpty(getNestedValue(item, parsed.path));
+      const { path: itemPath, language } = splitLanguageSuffix(parsed.path);
+      const lang = language ?? opts?.language ?? null;
+      // Schema-aware resolution handles deep relations (e.g. nested translations);
+      // without a resolver, fall back to a plain dotted lookup (M2O chains, scalars).
+      const value = opts?.describeHop
+        ? resolveRelationalPath(item, itemPath, parsed.collection, opts.describeHop, lang)
+        : getNestedValue(item, itemPath);
+      return scalarOrEmpty(value);
     }
 
     // 3. Other junction-level field (prefixed, e.g. `treatment.sort`).

--- a/src/utils/resolveRelationalPath.ts
+++ b/src/utils/resolveRelationalPath.ts
@@ -32,6 +32,20 @@ const TO_ONE = new Set<HopKind>(['m2o', 'file']);
 /** Hop kinds whose value is a to-many array with no single-cell representation. */
 const TO_MANY = new Set<HopKind>(['o2m', 'm2m', 'm2a', 'files']);
 
+/**
+ * Split a dotted relational path into walkable segments: trims whitespace,
+ * drops empty segments and Directus virtual segments (e.g. `$thumbnail`).
+ * Canonical splitter for every schema walk — query building, validation and
+ * rendering must tokenize identically, or a path could validate differently
+ * than it resolves.
+ */
+export function splitPathSegments(path: string): string[] {
+  return path
+    .split('.')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !s.startsWith('$'));
+}
+
 export function resolveRelationalPath(
   data: unknown,
   path: string,
@@ -40,10 +54,7 @@ export function resolveRelationalPath(
   language: string | null
 ): unknown {
   // Skip Directus virtual segments (e.g. `$thumbnail`) like the rest of the codebase.
-  const segments = path
-    .split('.')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0 && !s.startsWith('$'));
+  const segments = splitPathSegments(path);
 
   let current: unknown = data;
   let collection: string | null = startCollection;
@@ -85,10 +96,7 @@ export function collectTranslationLanguagePaths(
   startCollection: string | null,
   describeHop: DescribeHop
 ): string[] {
-  const segments = path
-    .split('.')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0 && !s.startsWith('$'));
+  const segments = splitPathSegments(path);
 
   const out: string[] = [];
   const acc: string[] = [];

--- a/src/utils/resolveRelationalPath.ts
+++ b/src/utils/resolveRelationalPath.ts
@@ -1,0 +1,129 @@
+/**
+ * Generic, schema-driven resolver for a dotted path through relational data.
+ *
+ * It walks the path one hop at a time and asks `describeHop` what each hop is,
+ * so it scales to arbitrary depth without per-level special-casing:
+ *   - `m2o` / `file`        → descend into the related object
+ *   - `translations`        → array of language rows; pick the row matching the
+ *                             active language via the *detected* language field
+ *   - `o2m` / `m2m` / `m2a` / `files` → to-many array; take the first element
+ *                             (a single table cell can't render a collection;
+ *                             this is the documented boundary)
+ *   - `scalar` / unknown    → read the value and stop traversing
+ *
+ * Pure: all schema knowledge is injected through `describeHop`, so this is
+ * unit-testable without the Directus stores.
+ */
+
+export type HopKind = 'scalar' | 'm2o' | 'o2m' | 'm2m' | 'm2a' | 'file' | 'files' | 'translations';
+
+export interface HopInfo {
+  kind: HopKind;
+  /** Collection to continue resolving on after this hop (null when unknown). */
+  relatedCollection?: string | null;
+  /** For `translations`: the junction field that holds the language code. */
+  languageField?: string | null;
+}
+
+export type DescribeHop = (collection: string, field: string) => HopInfo;
+
+/** Hop kinds whose value is a to-one related object we descend into. */
+const TO_ONE = new Set<HopKind>(['m2o', 'file']);
+/** Hop kinds whose value is a to-many array with no single-cell representation. */
+const TO_MANY = new Set<HopKind>(['o2m', 'm2m', 'm2a', 'files']);
+
+export function resolveRelationalPath(
+  data: unknown,
+  path: string,
+  startCollection: string | null,
+  describeHop: DescribeHop,
+  language: string | null
+): unknown {
+  // Skip Directus virtual segments (e.g. `$thumbnail`) like the rest of the codebase.
+  const segments = path
+    .split('.')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !s.startsWith('$'));
+
+  let current: unknown = data;
+  let collection: string | null = startCollection;
+
+  for (const segment of segments) {
+    if (current == null || typeof current !== 'object') return undefined;
+
+    const hop: HopInfo = collection ? describeHop(collection, segment) : { kind: 'scalar' };
+    const raw = (current as Record<string, unknown>)[segment];
+
+    if (hop.kind === 'translations') {
+      current = pickTranslationRow(raw, language, hop.languageField);
+      collection = hop.relatedCollection ?? null;
+    } else if (TO_MANY.has(hop.kind)) {
+      current = Array.isArray(raw) ? (raw[0] ?? null) : raw;
+      collection = hop.relatedCollection ?? null;
+    } else if (TO_ONE.has(hop.kind)) {
+      current = raw;
+      collection = hop.relatedCollection ?? null;
+    } else {
+      // scalar / unknown: read and stop traversing relations
+      current = raw;
+      collection = null;
+    }
+  }
+
+  return current;
+}
+
+/**
+ * For a dotted path, return the sub-path to the language field of every
+ * `translations` hop along the way. The query side must fetch these so the
+ * renderer has the language column to match the active language against
+ * (otherwise it can only fall back to the first row). Empty when the path
+ * crosses no translations relation.
+ */
+export function collectTranslationLanguagePaths(
+  path: string,
+  startCollection: string | null,
+  describeHop: DescribeHop
+): string[] {
+  const segments = path
+    .split('.')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !s.startsWith('$'));
+
+  const out: string[] = [];
+  const acc: string[] = [];
+  let collection = startCollection;
+
+  for (const segment of segments) {
+    const hop: HopInfo = collection ? describeHop(collection, segment) : { kind: 'scalar' };
+    acc.push(segment);
+    if (hop.kind === 'translations' && hop.languageField) {
+      out.push([...acc, hop.languageField].join('.'));
+    }
+    collection = hop.relatedCollection ?? null;
+  }
+  return out;
+}
+
+/**
+ * From a translations array, return the row for the active language (matched on
+ * the detected language field), falling back to the first row when the language
+ * is absent. Returns null for a non-array / empty value.
+ */
+function pickTranslationRow(
+  value: unknown,
+  language: string | null,
+  languageField: string | null | undefined
+): Record<string, unknown> | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const field = languageField ?? 'languages_code';
+  if (language != null) {
+    const match = value.find(
+      (row) =>
+        row && typeof row === 'object' && (row as Record<string, unknown>)[field] === language
+    );
+    if (match) return match as Record<string, unknown>;
+  }
+  const first = value[0];
+  return first && typeof first === 'object' ? (first as Record<string, unknown>) : null;
+}

--- a/src/utils/searchSync.ts
+++ b/src/utils/searchSync.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure helpers for syncing the native layout `search` prop with the internal
+ * search-query ref. Extracted from super-table.vue so the (otherwise
+ * component-bound) normalization rules are unit-testable.
+ */
+
+/**
+ * Normalize the native `search` prop into the internal searchQuery model.
+ * Directus core represents "no search" as null; the v-input model wants ''.
+ */
+export function normalizeIncomingSearch(value: string | null | undefined): string {
+  return value ?? '';
+}
+
+/**
+ * Normalize the internal searchQuery for the `update:search` emit: an
+ * empty/whitespace-only query collapses to null, matching native search
+ * semantics ("" is not a search).
+ */
+export function normalizeOutgoingSearch(value: string): string | null {
+  return value.trim() === '' ? null : value;
+}

--- a/src/utils/stripHtml.ts
+++ b/src/utils/stripHtml.ts
@@ -1,0 +1,32 @@
+/**
+ * Convert an HTML fragment to plain text: all tags removed, `<script>`/`<style>`
+ * contents dropped entirely, ALL entities decoded (named and numeric),
+ * whitespace collapsed.
+ *
+ * M2A template cells interpolate resolved values as text, so a rich-text
+ * translation field would otherwise show its literal markup — unlike normal
+ * columns, which go through the native `formatted-value` display (DOMPurify
+ * with `ALLOWED_TAGS: []` + html-entities decode). Neither of those packages
+ * is importable from an extension and a hand-rolled regex/entity table misses
+ * real WYSIWYG output (`&nbsp;`, numeric entities, `>` inside attributes), so
+ * this uses the browser's own parser. DOMParser documents are inert — no
+ * script execution, no resource loading — which makes this safe for
+ * untrusted values.
+ */
+export function stripHtml(value: unknown): string {
+  if (value == null) return '';
+  const source = String(value);
+  // Fast path: nothing to strip or decode — the dominant case (plain names,
+  // numbers) skips the comparatively expensive document parse entirely.
+  if (!/[<&]/.test(source)) return source.replace(/\s+/g, ' ').trim();
+  // A space before every "<" keeps words from gluing together when the parser
+  // drops the tags ("<p>a</p><p>b</p>" → "a b", not "ab"). In plain text a "<"
+  // followed by whitespace is not markup, so values like "a < b" survive.
+  const doc = new DOMParser().parseFromString(source.replace(/</g, ' <'), 'text/html');
+  // The native display (DOMPurify) drops script/style CONTENT, not just the
+  // tags — and browser vs happy-dom parsers disagree where such elements land,
+  // so removing them explicitly also keeps both environments consistent.
+  doc.body.querySelectorAll('script,style').forEach((el) => el.remove());
+  const text = doc.body.textContent ?? '';
+  return text.replace(/\s+/g, ' ').trim();
+}

--- a/src/utils/warnOnce.ts
+++ b/src/utils/warnOnce.ts
@@ -1,0 +1,21 @@
+/**
+ * Console-warn that emits each distinct message only once per session.
+ *
+ * Layout computeds re-run on every reactive recompute (pagination, sort,
+ * language switch, ...); a stale template token would otherwise re-log the
+ * same drop warning on every pass. The cache is keyed by the full message
+ * and deliberately unbounded: its size is capped by the number of distinct
+ * invalid template tokens a user can produce, which is tiny in practice.
+ */
+const warned = new Set<string>();
+
+export function warnOnce(message: string): void {
+  if (warned.has(message)) return;
+  warned.add(message);
+  console.warn(message);
+}
+
+/** Test-only: clear the dedupe cache so each test observes its own warning. */
+export function __resetWarnOnce(): void {
+  warned.clear();
+}

--- a/tests/unit/utils/adjustFieldsForDisplays.test.ts
+++ b/tests/unit/utils/adjustFieldsForDisplays.test.ts
@@ -263,32 +263,38 @@ describe('adjustFieldsForDisplays — M2A (issue #60)', () => {
               return { field: f };
             if (col === 'service' && f === 'name') return { field: 'name' };
             if (col === 'orders' && f === 'code') return { field: 'code' };
+            if (col === 'catalog' && f === 'title') return { field: 'title' };
             return null;
           },
           getFieldsForCollection: () => [],
         }),
         useRelationsStore: () => ({
-          getRelationsForField: (col: string, f: string) =>
-            col === 'orders' && f === 'treatment'
-              ? [
-                  {
-                    collection: 'orders_treatment',
-                    field: 'orders_id',
-                    related_collection: 'orders',
-                    meta: { junction_field: 'item' },
+          getRelationsForField: (col: string, f: string) => {
+            if (col === 'orders' && f === 'treatment')
+              return [
+                {
+                  collection: 'orders_treatment',
+                  field: 'orders_id',
+                  related_collection: 'orders',
+                  meta: { junction_field: 'item' },
+                },
+                {
+                  collection: 'orders_treatment',
+                  field: 'item',
+                  related_collection: null,
+                  meta: {
+                    one_collection_field: 'collection',
+                    one_allowed_collections: ['partners_catalog', 'service'],
+                    junction_field: 'orders_id',
                   },
-                  {
-                    collection: 'orders_treatment',
-                    field: 'item',
-                    related_collection: null,
-                    meta: {
-                      one_collection_field: 'collection',
-                      one_allowed_collections: ['partners_catalog', 'service'],
-                      junction_field: 'orders_id',
-                    },
-                  },
-                ]
-              : [],
+                },
+              ];
+            if (col === 'partners_catalog' && f === 'catalog_id')
+              return [
+                { collection: 'partners_catalog', field: 'catalog_id', related_collection: 'catalog' },
+              ];
+            return [];
+          },
         }),
       }),
       useCollection: () => ({ primaryKeyField: { value: { field: 'id' } } }),

--- a/tests/unit/utils/buildNestedM2ADeep.test.ts
+++ b/tests/unit/utils/buildNestedM2ADeep.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildNestedM2ADeep } from '@/utils/buildNestedM2ADeep';
+import { buildNestedM2ADeep, mergeNestedM2ADeep } from '@/utils/buildNestedM2ADeep';
 import type { DescribeHop, HopInfo } from '@/utils/resolveRelationalPath';
 import { buildM2AFieldPath } from '@/utils/displayHeuristics';
 
@@ -134,5 +134,43 @@ describe('buildNestedM2ADeep', () => {
         'item:service': { translations: { _limit: -1, tags: { _limit: -1 } } },
       },
     });
+  });
+});
+
+describe('mergeNestedM2ADeep', () => {
+  it('adds the M2A default for a field absent from deepFields', () => {
+    const deepFields: Record<string, any> = {};
+    mergeNestedM2ADeep(deepFields, { treatment: { 'item:service': { translations: { _limit: -1 } } } });
+    expect(deepFields).toEqual({
+      treatment: { _fields: ['*'], _limit: -1, 'item:service': { translations: { _limit: -1 } } },
+    });
+  });
+
+  it('preserves an existing field entry and adds the scope keys', () => {
+    const deepFields: Record<string, any> = { treatment: { _fields: ['*'], _limit: -1 } };
+    mergeNestedM2ADeep(deepFields, { treatment: { 'item:service': { translations: { _limit: -1 } } } });
+    expect(deepFields.treatment).toEqual({
+      _fields: ['*'],
+      _limit: -1,
+      'item:service': { translations: { _limit: -1 } },
+    });
+  });
+
+  it('merges multiple fields and returns the same object', () => {
+    const deepFields: Record<string, any> = { tags: { _fields: ['*'] } };
+    const out = mergeNestedM2ADeep(deepFields, {
+      treatment: { 'item:service': { translations: { _limit: -1 } } },
+      blocks: { 'item:content': { items: { _limit: -1 } } },
+    });
+    expect(out).toBe(deepFields);
+    expect(deepFields.tags).toEqual({ _fields: ['*'] });
+    expect(deepFields.treatment['item:service']).toEqual({ translations: { _limit: -1 } });
+    expect(deepFields.blocks['item:content']).toEqual({ items: { _limit: -1 } });
+  });
+
+  it('is a no-op for empty nested input', () => {
+    const deepFields: Record<string, any> = { treatment: { _fields: ['*'], _limit: -1 } };
+    mergeNestedM2ADeep(deepFields, {});
+    expect(deepFields).toEqual({ treatment: { _fields: ['*'], _limit: -1 } });
   });
 });

--- a/tests/unit/utils/buildNestedM2ADeep.test.ts
+++ b/tests/unit/utils/buildNestedM2ADeep.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { buildNestedM2ADeep } from '@/utils/buildNestedM2ADeep';
+import type { DescribeHop, HopInfo } from '@/utils/resolveRelationalPath';
+import { buildM2AFieldPath } from '@/utils/displayHeuristics';
+
+const makeDescribeHop =
+  (hopMap: Record<string, Record<string, HopInfo>>): DescribeHop =>
+  (collection, field) =>
+    hopMap[collection]?.[field] ?? { kind: 'scalar' };
+
+describe('buildNestedM2ADeep', () => {
+  it('emits _limit:-1 for a translations hop directly on the target', () => {
+    const describeHop = makeDescribeHop({
+      service: {
+        translations: {
+          kind: 'translations',
+          relatedCollection: 'service_translations',
+          languageField: 'languages_code',
+        },
+      },
+    });
+    expect(
+      buildNestedM2ADeep(
+        ['treatment.item:service.translations.label', 'treatment.item:service.translations.languages_code'],
+        describeHop
+      )
+    ).toEqual({
+      treatment: { 'item:service': { translations: { _limit: -1 } } },
+    });
+  });
+
+  it('nests the entry under intermediate to-one hops (m2o -> translations)', () => {
+    const describeHop = makeDescribeHop({
+      service: { author: { kind: 'm2o', relatedCollection: 'users' } },
+      users: {
+        translations: { kind: 'translations', relatedCollection: 'users_translations' },
+      },
+    });
+    expect(
+      buildNestedM2ADeep(['treatment.item:service.author.translations.bio'], describeHop)
+    ).toEqual({
+      treatment: { 'item:service': { author: { translations: { _limit: -1 } } } },
+    });
+  });
+
+  it('covers o2m/m2m/files hops, not just translations', () => {
+    const describeHop = makeDescribeHop({
+      service: { attachments: { kind: 'files', relatedCollection: 'directus_files' } },
+    });
+    expect(
+      buildNestedM2ADeep(['treatment.item:service.attachments.id'], describeHop)
+    ).toEqual({
+      treatment: { 'item:service': { attachments: { _limit: -1 } } },
+    });
+  });
+
+  it('returns nothing for scalar-only or to-one-only paths', () => {
+    const describeHop = makeDescribeHop({
+      service: { author: { kind: 'm2o', relatedCollection: 'users' } },
+      users: { name: { kind: 'scalar' } },
+    });
+    expect(
+      buildNestedM2ADeep(
+        ['treatment.item:service.name', 'treatment.item:service.author.name'],
+        describeHop
+      )
+    ).toEqual({});
+  });
+
+  it('merges multiple target collections and multiple M2A fields', () => {
+    const describeHop = makeDescribeHop({
+      service: { translations: { kind: 'translations', relatedCollection: 'service_translations' } },
+      partners: { items: { kind: 'm2m', relatedCollection: 'partner_items' } },
+    });
+    expect(
+      buildNestedM2ADeep(
+        [
+          'treatment.item:service.translations.label',
+          'treatment.item:partners.items.id',
+          'blocks.item:service.translations.label',
+        ],
+        describeHop
+      )
+    ).toEqual({
+      treatment: {
+        'item:service': { translations: { _limit: -1 } },
+        'item:partners': { items: { _limit: -1 } },
+      },
+      blocks: { 'item:service': { translations: { _limit: -1 } } },
+    });
+  });
+
+  it('ignores non-M2A paths (no item: scope) and bare fields', () => {
+    const describeHop = makeDescribeHop({});
+    expect(
+      buildNestedM2ADeep(['code', 'tags.tag_id.name', 'translations.title'], describeHop)
+    ).toEqual({});
+  });
+
+  it('round-trips paths built by buildM2AFieldPath (drift guard for the emit shape)', () => {
+    const describeHop = makeDescribeHop({
+      service: {
+        translations: { kind: 'translations', relatedCollection: 'service_translations' },
+      },
+    });
+    const emitted = buildM2AFieldPath('treatment', 'item', 'service', 'translations.label');
+    expect(buildNestedM2ADeep([emitted], describeHop)).toEqual({
+      treatment: { 'item:service': { translations: { _limit: -1 } } },
+    });
+  });
+
+  it('handles a to-many hop as the LAST segment', () => {
+    const describeHop = makeDescribeHop({
+      service: {
+        translations: { kind: 'translations', relatedCollection: 'service_translations' },
+      },
+    });
+    expect(buildNestedM2ADeep(['treatment.item:service.translations'], describeHop)).toEqual({
+      treatment: { 'item:service': { translations: { _limit: -1 } } },
+    });
+  });
+
+  it('emits limits for MULTIPLE to-many hops along one path', () => {
+    const describeHop = makeDescribeHop({
+      service: {
+        translations: { kind: 'translations', relatedCollection: 'service_translations' },
+      },
+      service_translations: { tags: { kind: 'o2m', relatedCollection: 'tags' } },
+    });
+    expect(
+      buildNestedM2ADeep(['treatment.item:service.translations.tags.name'], describeHop)
+    ).toEqual({
+      treatment: {
+        'item:service': { translations: { _limit: -1, tags: { _limit: -1 } } },
+      },
+    });
+  });
+});

--- a/tests/unit/utils/buildQueryFingerprint.test.ts
+++ b/tests/unit/utils/buildQueryFingerprint.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { buildQueryFingerprint, type QueryFingerprintInput } from '@/utils/buildQueryFingerprint';
+
+const base: QueryFingerprintInput = {
+  collection: 'orders',
+  fields: ['code', 'treatment'],
+  filter: null,
+  sort: ['code'],
+  page: 1,
+  limit: 25,
+  deep: null,
+  alias: null,
+};
+
+describe('buildQueryFingerprint', () => {
+  it('is stable for identical input', () => {
+    expect(buildQueryFingerprint(base)).toBe(buildQueryFingerprint({ ...base }));
+  });
+
+  it('normalizes nullish filter/deep/alias to null', () => {
+    const a = buildQueryFingerprint({ ...base, filter: undefined, deep: undefined, alias: undefined });
+    const b = buildQueryFingerprint({ ...base, filter: null, deep: null, alias: null });
+    expect(a).toBe(b);
+  });
+
+  it('changes when ANY fetch parameter changes (guards against a dropped key)', () => {
+    const fp = buildQueryFingerprint(base);
+    expect(buildQueryFingerprint({ ...base, collection: 'orders_simple' })).not.toBe(fp);
+    expect(buildQueryFingerprint({ ...base, fields: ['code'] })).not.toBe(fp);
+    expect(buildQueryFingerprint({ ...base, filter: { code: { _eq: 'X' } } })).not.toBe(fp);
+    expect(buildQueryFingerprint({ ...base, sort: ['-code'] })).not.toBe(fp);
+    expect(buildQueryFingerprint({ ...base, page: 2 })).not.toBe(fp);
+    expect(buildQueryFingerprint({ ...base, limit: 50 })).not.toBe(fp);
+    expect(buildQueryFingerprint({ ...base, deep: { treatment: { _limit: -1 } } })).not.toBe(fp);
+    expect(buildQueryFingerprint({ ...base, alias: { x: 'y' } })).not.toBe(fp);
+  });
+});

--- a/tests/unit/utils/buildTemplateToken.test.ts
+++ b/tests/unit/utils/buildTemplateToken.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { buildTemplateToken } from '@/utils/buildTemplateToken';
+
+describe('buildTemplateToken', () => {
+  it('builds the M2A discriminator token', () => {
+    expect(buildTemplateToken({ mode: 'm2a-collection', fieldKey: 'treatment' })).toBe(
+      '{{treatment.collection}}'
+    );
+  });
+
+  it('builds an M2A item token without a language', () => {
+    expect(
+      buildTemplateToken({ mode: 'm2a-item', fieldKey: 'treatment', targetCollection: 'service', path: 'name' })
+    ).toBe('{{treatment.item:service.name}}');
+  });
+
+  it('builds an M2A nested-translation token with a language suffix', () => {
+    expect(
+      buildTemplateToken({
+        mode: 'm2a-item',
+        fieldKey: 'treatment',
+        targetCollection: 'service',
+        path: 'translations.label',
+        language: 'de-DE',
+      })
+    ).toBe('{{treatment.item:service.translations.label:de-DE}}');
+  });
+
+  it('treats null/empty language as no suffix', () => {
+    const base = { mode: 'm2a-item', fieldKey: 'treatment', targetCollection: 'service', path: 'translations.label' } as const;
+    expect(buildTemplateToken({ ...base, language: null })).toBe(
+      '{{treatment.item:service.translations.label}}'
+    );
+    expect(buildTemplateToken({ ...base, language: '' })).toBe(
+      '{{treatment.item:service.translations.label}}'
+    );
+  });
+
+  it('builds a relative (non-M2A) token', () => {
+    expect(buildTemplateToken({ mode: 'relative', path: 'first_name' })).toBe('{{first_name}}');
+    expect(buildTemplateToken({ mode: 'relative', path: 'author.role.name' })).toBe(
+      '{{author.role.name}}'
+    );
+  });
+});

--- a/tests/unit/utils/coalesce.test.ts
+++ b/tests/unit/utils/coalesce.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createCoalescedRunner } from '@/utils/coalesce';
+
+const flushMicrotasks = async (rounds = 4): Promise<void> => {
+  for (let i = 0; i < rounds; i++) await Promise.resolve();
+};
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => (resolve = res));
+  return { promise, resolve };
+}
+
+describe('createCoalescedRunner', () => {
+  it('collapses N synchronous triggers into one execution', async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const schedule = createCoalescedRunner(fn);
+    schedule();
+    schedule();
+    schedule();
+    expect(fn).not.toHaveBeenCalled();
+    await flushMicrotasks();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads the LATEST state at execution time (final state wins)', async () => {
+    let value = 'initial';
+    const seen: string[] = [];
+    const schedule = createCoalescedRunner(async () => {
+      seen.push(value);
+    });
+    schedule();
+    value = 'final';
+    await flushMicrotasks();
+    expect(seen).toEqual(['final']);
+  });
+
+  it('a trigger DURING execution schedules exactly one follow-up run', async () => {
+    const gate = deferred();
+    let calls = 0;
+    const schedule = createCoalescedRunner(async () => {
+      calls++;
+      if (calls === 1) await gate.promise;
+    });
+    schedule();
+    await flushMicrotasks();
+    expect(calls).toBe(1);
+    schedule();
+    schedule();
+    schedule();
+    gate.resolve();
+    await flushMicrotasks();
+    expect(calls).toBe(2);
+  });
+
+  it('settled promise resolves only after the final (re-)run', async () => {
+    const gate = deferred();
+    const order: string[] = [];
+    let calls = 0;
+    const schedule = createCoalescedRunner(async () => {
+      calls++;
+      if (calls === 1) await gate.promise;
+      order.push(`run${calls}`);
+    });
+    const p1 = schedule();
+    await flushMicrotasks();
+    const p2 = schedule();
+    gate.resolve();
+    await Promise.all([p1, p2]);
+    expect(order).toEqual(['run1', 'run2']);
+  });
+
+  it('recovers after a rejected execution', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue(undefined);
+    const schedule = createCoalescedRunner(fn);
+    await expect(schedule()).rejects.toThrow('boom');
+    schedule();
+    await flushMicrotasks();
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT dedupe across separate ticks (documented limitation)', async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const schedule = createCoalescedRunner(fn);
+    schedule();
+    await flushMicrotasks();
+    schedule();
+    await flushMicrotasks();
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/utils/describeHop.test.ts
+++ b/tests/unit/utils/describeHop.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { createDescribeHop } from '@/utils/describeHop';
+
+const makeStores = (fields: Record<string, any>, relations: Record<string, any[]>) => ({
+  fieldsStore: { getField: (c: string, f: string) => fields[`${c}.${f}`] ?? null },
+  relationsStore: { getRelationsForField: (c: string, f: string) => relations[`${c}.${f}`] ?? [] },
+});
+
+describe('createDescribeHop', () => {
+  it('describes a translations hop with the DETECTED language field (junction_field)', () => {
+    const { fieldsStore, relationsStore } = makeStores(
+      { 'service.translations': { meta: { special: ['translations'] } } },
+      {
+        'service.translations': [
+          {
+            collection: 'service_translations',
+            field: 'service_id',
+            related_collection: 'service',
+            meta: { one_field: 'translations', junction_field: 'languages_code' },
+          },
+        ],
+      }
+    );
+    const describe = createDescribeHop(fieldsStore as any, relationsStore as any);
+    expect(describe('service', 'translations')).toEqual({
+      kind: 'translations',
+      relatedCollection: 'service_translations',
+      languageField: 'languages_code',
+    });
+  });
+
+  it('detects a non-default language field name', () => {
+    const { fieldsStore, relationsStore } = makeStores(
+      { 'catalog.translations': { meta: { special: ['translations'] } } },
+      {
+        'catalog.translations': [
+          {
+            collection: 'catalog_translations',
+            field: 'catalog_id',
+            related_collection: 'catalog',
+            meta: { one_field: 'translations', junction_field: 'lang' },
+          },
+        ],
+      }
+    );
+    const describe = createDescribeHop(fieldsStore as any, relationsStore as any);
+    expect(describe('catalog', 'translations').languageField).toBe('lang');
+  });
+
+  it('describes an M2O hop with its related collection', () => {
+    const { fieldsStore, relationsStore } = makeStores(
+      { 'partners_catalog.catalog_id': { meta: { special: ['m2o'] } } },
+      {
+        'partners_catalog.catalog_id': [
+          { collection: 'partners_catalog', field: 'catalog_id', related_collection: 'catalog', meta: {} },
+        ],
+      }
+    );
+    const describe = createDescribeHop(fieldsStore as any, relationsStore as any);
+    expect(describe('partners_catalog', 'catalog_id')).toEqual({
+      kind: 'm2o',
+      relatedCollection: 'catalog',
+    });
+  });
+
+  it('describes a plain scalar field', () => {
+    const { fieldsStore, relationsStore } = makeStores(
+      { 'service.name': { meta: {} } },
+      {}
+    );
+    const describe = createDescribeHop(fieldsStore as any, relationsStore as any);
+    expect(describe('service', 'name')).toEqual({ kind: 'scalar' });
+  });
+
+  it('describes a to-many m2m hop as an array kind', () => {
+    const { fieldsStore, relationsStore } = makeStores(
+      { 'orders.tags': { meta: { special: ['m2m'] } } },
+      {
+        'orders.tags': [
+          {
+            collection: 'orders_tags',
+            field: 'orders_id',
+            related_collection: 'orders',
+            meta: { junction_field: 'tag_id' },
+          },
+        ],
+      }
+    );
+    const describe = createDescribeHop(fieldsStore as any, relationsStore as any);
+    expect(describe('orders', 'tags').kind).toBe('m2m');
+  });
+
+  it('is defensive: unknown field → scalar, store throwing → scalar', () => {
+    const describe = createDescribeHop(
+      { getField: () => null } as any,
+      {
+        getRelationsForField: () => {
+          throw new Error('store not ready');
+        },
+      } as any
+    );
+    expect(describe('x', 'y')).toEqual({ kind: 'scalar' });
+  });
+});

--- a/tests/unit/utils/displayHeuristics.test.ts
+++ b/tests/unit/utils/displayHeuristics.test.ts
@@ -10,6 +10,7 @@ import {
   isM2APrefix,
   stripM2AFieldPrefix,
   splitLanguageSuffix,
+  stripLanguageSuffix,
 } from '@/utils/displayHeuristics';
 
 describe('isRelational', () => {
@@ -424,5 +425,21 @@ describe('splitLanguageSuffix', () => {
       language: null,
     });
     expect(splitLanguageSuffix('name')).toEqual({ path: 'name', language: null });
+  });
+});
+
+describe('stripLanguageSuffix', () => {
+  it('returns the key unchanged when there is no suffix', () => {
+    expect(stripLanguageSuffix('title')).toBe('title');
+    expect(stripLanguageSuffix('translations.description')).toBe('translations.description');
+  });
+  it('strips a single trailing language suffix', () => {
+    expect(stripLanguageSuffix('translations.description:de-DE')).toBe('translations.description');
+  });
+  it('strips only the LAST colon segment (documents last-colon semantics)', () => {
+    expect(stripLanguageSuffix('a:b:de-DE')).toBe('a:b');
+  });
+  it('handles an empty trailing suffix', () => {
+    expect(stripLanguageSuffix('x:')).toBe('x');
   });
 });

--- a/tests/unit/utils/displayHeuristics.test.ts
+++ b/tests/unit/utils/displayHeuristics.test.ts
@@ -9,6 +9,7 @@ import {
   buildM2AFieldPath,
   isM2APrefix,
   stripM2AFieldPrefix,
+  splitLanguageSuffix,
 } from '@/utils/displayHeuristics';
 
 describe('isRelational', () => {
@@ -406,5 +407,22 @@ describe('stripM2AFieldPrefix', () => {
 
   it('returns the token unchanged when no field name is given', () => {
     expect(stripM2AFieldPrefix('treatment.collection', '')).toBe('treatment.collection');
+  });
+});
+
+describe('splitLanguageSuffix', () => {
+  it('splits a trailing :language off the path', () => {
+    expect(splitLanguageSuffix('translations.label:de-DE')).toEqual({
+      path: 'translations.label',
+      language: 'de-DE',
+    });
+  });
+
+  it('returns language null when there is no suffix', () => {
+    expect(splitLanguageSuffix('catalog_id.title')).toEqual({
+      path: 'catalog_id.title',
+      language: null,
+    });
+    expect(splitLanguageSuffix('name')).toEqual({ path: 'name', language: null });
   });
 });

--- a/tests/unit/utils/expandTokensThroughRelation.test.ts
+++ b/tests/unit/utils/expandTokensThroughRelation.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { expandTokensThroughRelation } from '@/utils/adjustFieldsForDisplays';
+import { __resetWarnOnce } from '@/utils/warnOnce';
 
 const makeStores = (
   fieldsByPath: Record<string, any>,
@@ -14,6 +15,12 @@ const makeStores = (
 });
 
 describe('expandTokensThroughRelation', () => {
+  // warnOnce dedupes per module instance; this file imports the module
+  // statically, so reset the cache to keep every test order-independent.
+  beforeEach(() => {
+    __resetWarnOnce();
+  });
+
   it('returns fieldKey.token for plain M2O when target field exists', () => {
     const { fieldsStore, relationsStore } = makeStores(
       { 'directus_users.first_name': { field: 'first_name' } },
@@ -136,7 +143,8 @@ describe('expandTokensThroughRelation', () => {
           field: 'tag_id',
           schema: { foreign_key_table: 'tags' },
         },
-        'tags.category': { field: 'category' },
+        'tags.category': { field: 'category', meta: { special: ['m2o'] } },
+        'categories.name': { field: 'name' },
       },
       {
         'products.product_tags': [
@@ -146,6 +154,9 @@ describe('expandTokensThroughRelation', () => {
             related_collection: 'products',
             meta: { junction_field: 'tag_id' },
           },
+        ],
+        'tags.category': [
+          { collection: 'tags', field: 'category', related_collection: 'categories' },
         ],
       }
     );
@@ -281,6 +292,11 @@ describe('expandTokensThroughRelation', () => {
           // validate bare parent tokens and field-prefixed junction tokens.
           'orders.code': { field: 'code' },
           'orders_treatment.sort': { field: 'sort' },
+          // Junction- and parent-level M2O hops for deep junction/parent tokens.
+          'orders_treatment.added_by': { field: 'added_by', meta: { special: ['m2o'] } },
+          'directus_users.email': { field: 'email' },
+          'orders.customer': { field: 'customer', meta: { special: ['m2o'] } },
+          'customers.email': { field: 'email' },
         },
         {
           'orders.treatment': [
@@ -311,6 +327,16 @@ describe('expandTokensThroughRelation', () => {
               related_collection: 'service',
               meta: { one_field: 'translations', junction_field: 'languages_code' },
             },
+          ],
+          'orders_treatment.added_by': [
+            {
+              collection: 'orders_treatment',
+              field: 'added_by',
+              related_collection: 'directus_users',
+            },
+          ],
+          'orders.customer': [
+            { collection: 'orders', field: 'customer', related_collection: 'customers' },
           ],
         }
       );
@@ -628,5 +654,247 @@ describe('expandTokensThroughRelation', () => {
       expect(warnSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
     });
+
+    it('emits a deep junction token when every segment exists (M2A junction)', () => {
+      const { fieldsStore, relationsStore } = m2aStores();
+      const result = expandTokensThroughRelation(
+        m2aField,
+        'treatment',
+        'orders',
+        ['treatment.added_by.email'],
+        fieldsStore as any,
+        relationsStore as any
+      );
+      expect(result).toEqual(['treatment.collection', 'treatment.added_by.email']);
+    });
+
+    it('drops a deep junction token whose leaf is missing, with a warning', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { fieldsStore, relationsStore } = m2aStores();
+      const result = expandTokensThroughRelation(
+        m2aField,
+        'treatment',
+        'orders',
+        ['treatment.added_by.ghost'],
+        fieldsStore as any,
+        relationsStore as any
+      );
+      expect(result).toEqual(['treatment.collection']);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('directus_users.ghost'));
+      warnSpy.mockRestore();
+    });
+
+    it('emits a deep parent token when every segment exists (M2A parent)', () => {
+      const { fieldsStore, relationsStore } = m2aStores();
+      const result = expandTokensThroughRelation(
+        m2aField,
+        'treatment',
+        'orders',
+        ['customer.email'],
+        fieldsStore as any,
+        relationsStore as any
+      );
+      expect(result).toEqual(['treatment.collection', 'customer.email']);
+    });
+
+    it('drops a deep parent token whose middle segment is scalar, with a warning', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { fieldsStore, relationsStore } = m2aStores();
+      const result = expandTokensThroughRelation(
+        m2aField,
+        'treatment',
+        'orders',
+        ['code.deeper'],
+        fieldsStore as any,
+        relationsStore as any
+      );
+      expect(result).toEqual(['treatment.collection']);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('orders.code'));
+      warnSpy.mockRestore();
+    });
+
+    it('warns only once for the same dropped token across recomputes (warnOnce)', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { fieldsStore, relationsStore } = m2aStores();
+      for (let i = 0; i < 3; i++) {
+        expandTokensThroughRelation(
+          m2aField,
+          'treatment',
+          'orders',
+          ['item:service.nonexistent'],
+          fieldsStore as any,
+          relationsStore as any
+        );
+      }
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      warnSpy.mockRestore();
+    });
+  });
+
+  it('keeps a valid deep M2M token without warning (per-segment walk)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fieldsStore, relationsStore } = makeStores(
+      {
+        'products_tags.tag_id': { field: 'tag_id', schema: { foreign_key_table: 'tags' } },
+        'tags.category': { field: 'category', meta: { special: ['m2o'] } },
+        'categories.name': { field: 'name' },
+      },
+      {
+        'products.product_tags': [
+          {
+            collection: 'products_tags',
+            field: 'product_id',
+            related_collection: 'products',
+            meta: { junction_field: 'tag_id' },
+          },
+        ],
+        'tags.category': [
+          { collection: 'tags', field: 'category', related_collection: 'categories' },
+        ],
+      }
+    );
+    const field = {
+      collection: 'products',
+      field: 'product_tags',
+      meta: { special: ['m2m'] },
+    } as any;
+    const result = expandTokensThroughRelation(
+      field,
+      'product_tags',
+      'products',
+      ['category.name'],
+      fieldsStore as any,
+      relationsStore as any
+    );
+    expect(result).toEqual(['product_tags.tag_id.category.name']);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('drops a deep M2M token whose leaf is missing on the deep target, with a warning', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fieldsStore, relationsStore } = makeStores(
+      {
+        'products_tags.tag_id': { field: 'tag_id', schema: { foreign_key_table: 'tags' } },
+        'tags.category': { field: 'category', meta: { special: ['m2o'] } },
+        'categories.name': { field: 'name' },
+      },
+      {
+        'products.product_tags': [
+          {
+            collection: 'products_tags',
+            field: 'product_id',
+            related_collection: 'products',
+            meta: { junction_field: 'tag_id' },
+          },
+        ],
+        'tags.category': [
+          { collection: 'tags', field: 'category', related_collection: 'categories' },
+        ],
+      }
+    );
+    const field = {
+      collection: 'products',
+      field: 'product_tags',
+      meta: { special: ['m2m'] },
+    } as any;
+    const result = expandTokensThroughRelation(
+      field,
+      'product_tags',
+      'products',
+      ['category.ghost'],
+      fieldsStore as any,
+      relationsStore as any
+    );
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('categories.ghost'));
+    warnSpy.mockRestore();
+  });
+
+  it('keeps a deep M2M token across a files hop — permissive, no warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fieldsStore, relationsStore } = makeStores(
+      {
+        'products_tags.tag_id': { field: 'tag_id', schema: { foreign_key_table: 'tags' } },
+        'tags.attachments': { field: 'attachments', meta: { special: ['files'] } },
+      },
+      {
+        'products.product_tags': [
+          {
+            collection: 'products_tags',
+            field: 'product_id',
+            related_collection: 'products',
+            meta: { junction_field: 'tag_id' },
+          },
+        ],
+      }
+    );
+    const field = {
+      collection: 'products',
+      field: 'product_tags',
+      meta: { special: ['m2m'] },
+    } as any;
+    const result = expandTokensThroughRelation(
+      field,
+      'product_tags',
+      'products',
+      ['attachments.directus_files_id.title'],
+      fieldsStore as any,
+      relationsStore as any
+    );
+    expect(result).toEqual(['product_tags.tag_id.attachments.directus_files_id.title']);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('keeps a valid deep M2O token after walking each segment (role.name)', () => {
+    const { fieldsStore, relationsStore } = makeStores(
+      {
+        'directus_users.role': { field: 'role', meta: { special: ['m2o'] } },
+        'directus_roles.name': { field: 'name' },
+      },
+      {
+        'parent.author': [
+          { collection: 'parent', field: 'author', related_collection: 'directus_users' },
+        ],
+        'directus_users.role': [
+          { collection: 'directus_users', field: 'role', related_collection: 'directus_roles' },
+        ],
+      }
+    );
+    const field = { collection: 'parent', field: 'author', meta: { special: ['m2o'] } } as any;
+    const result = expandTokensThroughRelation(
+      field,
+      'author',
+      'parent',
+      ['role.name'],
+      fieldsStore as any,
+      relationsStore as any
+    );
+    expect(result).toEqual(['author.role.name']);
+  });
+
+  it('drops a deep M2O token whose middle segment is scalar, with a warning', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fieldsStore, relationsStore } = makeStores(
+      { 'directus_users.first_name': { field: 'first_name' } },
+      {
+        'parent.author': [
+          { collection: 'parent', field: 'author', related_collection: 'directus_users' },
+        ],
+      }
+    );
+    const field = { collection: 'parent', field: 'author', meta: { special: ['m2o'] } } as any;
+    const result = expandTokensThroughRelation(
+      field,
+      'author',
+      'parent',
+      ['first_name.deeper'],
+      fieldsStore as any,
+      relationsStore as any
+    );
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('directus_users.first_name'));
+    warnSpy.mockRestore();
   });
 });

--- a/tests/unit/utils/expandTokensThroughRelation.test.ts
+++ b/tests/unit/utils/expandTokensThroughRelation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { expandTokensThroughRelation } from '@/utils/adjustFieldsForDisplays';
 
 const makeStores = (
@@ -270,8 +270,13 @@ describe('expandTokensThroughRelation', () => {
         {
           'partners_catalog.name': { field: 'name' },
           'partners_catalog.catalog_id': { field: 'catalog_id' },
+          'catalog.title': { field: 'title' },
           'service.name': { field: 'name' },
-          'service.translations': { field: 'translations' },
+          'service.translations': { field: 'translations', meta: { special: ['translations'] } },
+          'service.blocks': { field: 'blocks', meta: { special: ['m2a'] } },
+          'service.attachments': { field: 'attachments', meta: { special: ['files'] } },
+          'service_translations.label': { field: 'label' },
+          'service_translations.languages_code': { field: 'languages_code' },
           // Parent (orders) and junction (orders_treatment) own fields, used to
           // validate bare parent tokens and field-prefixed junction tokens.
           'orders.code': { field: 'code' },
@@ -294,6 +299,17 @@ describe('expandTokensThroughRelation', () => {
                 one_allowed_collections: ['partners_catalog', 'service'],
                 junction_field: 'orders_id',
               },
+            },
+          ],
+          'partners_catalog.catalog_id': [
+            { collection: 'partners_catalog', field: 'catalog_id', related_collection: 'catalog' },
+          ],
+          'service.translations': [
+            {
+              collection: 'service_translations',
+              field: 'service_id',
+              related_collection: 'service',
+              meta: { one_field: 'translations', junction_field: 'languages_code' },
             },
           ],
         }
@@ -474,8 +490,99 @@ describe('expandTokensThroughRelation', () => {
         fieldsStore as any,
         relationsStore as any
       );
-      // The :de-DE is dropped — Directus field paths must not carry it.
-      expect(result).toEqual(['treatment.collection', 'treatment.item:service.translations.label']);
+      // The language companion is emitted alongside (pre-existing behavior;
+      // the old mock just couldn't resolve the translations relation).
+      expect(result).toEqual([
+        'treatment.collection',
+        'treatment.item:service.translations.label',
+        'treatment.item:service.translations.languages_code',
+      ]);
+    });
+
+    it('drops a deep token whose leaf does not exist (validated per segment)', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { fieldsStore, relationsStore } = m2aStores();
+      const result = expandTokensThroughRelation(
+        m2aField,
+        'treatment',
+        'orders',
+        ['item:service.translations.missing_field'],
+        fieldsStore as any,
+        relationsStore as any
+      );
+      expect(result).toEqual(['treatment.collection']);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('missing_field'));
+      warnSpy.mockRestore();
+    });
+
+    it('drops a deep token whose middle segment is a scalar (not a relation)', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { fieldsStore, relationsStore } = m2aStores();
+      const result = expandTokensThroughRelation(
+        m2aField,
+        'treatment',
+        'orders',
+        ['item:service.name.deeper'],
+        fieldsStore as any,
+        relationsStore as any
+      );
+      expect(result).toEqual(['treatment.collection']);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('service.name'));
+      warnSpy.mockRestore();
+    });
+
+    it('emits a valid deep translations path together with its language companion', () => {
+      const { fieldsStore, relationsStore } = m2aStores();
+      const result = expandTokensThroughRelation(
+        m2aField,
+        'treatment',
+        'orders',
+        ['item:service.translations.label'],
+        fieldsStore as any,
+        relationsStore as any
+      );
+      expect(result).toEqual([
+        'treatment.collection',
+        'treatment.item:service.translations.label',
+        'treatment.item:service.translations.languages_code',
+      ]);
+    });
+
+    it('keeps a path it cannot walk further (nested M2A hop) — permissive, no warn', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { fieldsStore, relationsStore } = m2aStores();
+      const result = expandTokensThroughRelation(
+        m2aField,
+        'treatment',
+        'orders',
+        ['item:service.blocks.title'],
+        fieldsStore as any,
+        relationsStore as any
+      );
+      // `blocks` is an M2A hop (relatedCollection unknown) — validation stops
+      // and keeps the token instead of guessing.
+      expect(result).toEqual(['treatment.collection', 'treatment.item:service.blocks.title']);
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('keeps the token when the fields store throws mid-walk (early-boot safety)', () => {
+      const { fieldsStore, relationsStore } = m2aStores();
+      const throwingFieldsStore = {
+        getField: (col: string, f: string) => {
+          if (col === 'service_translations') throw new Error('store not hydrated');
+          return (fieldsStore as any).getField(col, f);
+        },
+      };
+      const result = expandTokensThroughRelation(
+        m2aField,
+        'treatment',
+        'orders',
+        ['item:service.translations.label'],
+        throwingFieldsStore as any,
+        relationsStore as any
+      );
+      expect(result).toContain('treatment.item:service.translations.label');
     });
 
     it('returns [] when the M2A item relation is missing (defensive)', () => {
@@ -501,6 +608,25 @@ describe('expandTokensThroughRelation', () => {
         relationsStore as any
       );
       expect(result).toEqual([]);
+    });
+
+    it('keeps a deep path across a files hop — permissive, no warn', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { fieldsStore, relationsStore } = m2aStores();
+      const result = expandTokensThroughRelation(
+        m2aField,
+        'treatment',
+        'orders',
+        ['item:service.attachments.directus_files_id.title'],
+        fieldsStore as any,
+        relationsStore as any
+      );
+      expect(result).toEqual([
+        'treatment.collection',
+        'treatment.item:service.attachments.directus_files_id.title',
+      ]);
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
   });
 });

--- a/tests/unit/utils/expandTokensThroughRelation.test.ts
+++ b/tests/unit/utils/expandTokensThroughRelation.test.ts
@@ -271,6 +271,7 @@ describe('expandTokensThroughRelation', () => {
           'partners_catalog.name': { field: 'name' },
           'partners_catalog.catalog_id': { field: 'catalog_id' },
           'service.name': { field: 'name' },
+          'service.translations': { field: 'translations' },
           // Parent (orders) and junction (orders_treatment) own fields, used to
           // validate bare parent tokens and field-prefixed junction tokens.
           'orders.code': { field: 'code' },
@@ -461,6 +462,20 @@ describe('expandTokensThroughRelation', () => {
         relationsStore as any
       );
       expect(result).toEqual(['treatment.collection']);
+    });
+
+    it('strips the :lang suffix from a nested translation token for the API path', () => {
+      const { fieldsStore, relationsStore } = m2aStores();
+      const result = expandTokensThroughRelation(
+        m2aField,
+        'treatment',
+        'orders',
+        ['treatment.item:service.translations.label:de-DE'],
+        fieldsStore as any,
+        relationsStore as any
+      );
+      // The :de-DE is dropped — Directus field paths must not carry it.
+      expect(result).toEqual(['treatment.collection', 'treatment.item:service.translations.label']);
     });
 
     it('returns [] when the M2A item relation is missing (defensive)', () => {

--- a/tests/unit/utils/fieldValidity.test.ts
+++ b/tests/unit/utils/fieldValidity.test.ts
@@ -5,7 +5,9 @@ import {
   filterValidFields,
   filterValidSort,
   filterValidColumnDisplays,
+  validateDeepPath,
 } from '@/utils/fieldValidity';
+import type { DescribeHop, HopInfo } from '@/utils/resolveRelationalPath';
 
 const COLLECTION = 'issue_47_test';
 const KNOWN_FIELDS = new Set(['id', 'title', 'status', 'price', 'translations', 'tags']);
@@ -190,5 +192,87 @@ describe('filterValidColumnDisplays', () => {
   it('returns {} when collection is null', () => {
     const input = { title: { template: '{{title}}' } };
     expect(filterValidColumnDisplays(input, null, fieldsStore)).toEqual({});
+  });
+});
+
+describe('validateDeepPath', () => {
+  const makeDescribeHop =
+    (map: Record<string, HopInfo>): DescribeHop =>
+    (collection, field) =>
+      map[`${collection}.${field}`] ?? { kind: 'scalar' };
+
+  const deepFieldsStore = {
+    getField: (collection: string | null, field: string) =>
+      [
+        'service.translations',
+        'service.name',
+        'service.blocks',
+        'service.attachments',
+        'service_translations.label',
+      ].includes(`${collection}.${field}`)
+        ? { collection, field }
+        : null,
+  };
+  const describeHop = makeDescribeHop({
+    'service.translations': { kind: 'translations', relatedCollection: 'service_translations' },
+    'service.blocks': { kind: 'm2a', relatedCollection: null },
+    'service.attachments': { kind: 'files', relatedCollection: 'directus_files' },
+  });
+
+  it('accepts a valid multi-hop path', () => {
+    expect(validateDeepPath('service', 'translations.label', deepFieldsStore, describeHop)).toEqual(
+      { valid: true }
+    );
+  });
+
+  it('rejects an unknown leaf with a reason naming the resolved collection', () => {
+    const r = validateDeepPath('service', 'translations.missing', deepFieldsStore, describeHop);
+    expect(r.valid).toBe(false);
+    expect(r.reason).toContain('service_translations.missing');
+  });
+
+  it('rejects a scalar middle segment', () => {
+    const r = validateDeepPath('service', 'name.deeper', deepFieldsStore, describeHop);
+    expect(r.valid).toBe(false);
+    expect(r.reason).toContain('service.name');
+  });
+
+  it('rejects an unknown root segment and an empty path', () => {
+    expect(validateDeepPath('service', 'ghost.label', deepFieldsStore, describeHop).valid).toBe(
+      false
+    );
+    expect(validateDeepPath('service', '', deepFieldsStore, describeHop).valid).toBe(false);
+  });
+
+  it('skips $-virtual segments like the renderer does', () => {
+    expect(
+      validateDeepPath('service', 'translations.$thumbnail.label', deepFieldsStore, describeHop)
+        .valid
+    ).toBe(true);
+  });
+
+  it('stays permissive when a hop cannot be walked further (unknown related collection)', () => {
+    expect(validateDeepPath('service', 'blocks.title', deepFieldsStore, describeHop).valid).toBe(
+      true
+    );
+  });
+
+  it('stays permissive when the fields store throws mid-walk', () => {
+    const throwing = {
+      getField: (collection: string | null, field: string) => {
+        if (collection === 'service_translations') throw new Error('not hydrated');
+        return deepFieldsStore.getField(collection, field);
+      },
+    };
+    expect(validateDeepPath('service', 'translations.label', throwing, describeHop).valid).toBe(
+      true
+    );
+  });
+
+  it('stays permissive across a files hop (junction level is not walkable)', () => {
+    expect(
+      validateDeepPath('service', 'attachments.directus_files_id.title', deepFieldsStore, describeHop)
+        .valid
+    ).toBe(true);
   });
 });

--- a/tests/unit/utils/filterUsesSome.test.ts
+++ b/tests/unit/utils/filterUsesSome.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { filterUsesSome } from '@/utils/filterUsesSome';
+
+describe('filterUsesSome', () => {
+  it('detects a top-level _some operator', () => {
+    const filter = { translations: { _some: { text: { _icontains: 'hello' } } } };
+    expect(filterUsesSome(filter)).toBe(true);
+  });
+
+  it('detects _some nested inside an _or array', () => {
+    const filter = {
+      _or: [
+        { title: { _icontains: 'hello' } },
+        { translations: { _some: { text: { _icontains: 'hello' } } } },
+      ],
+    };
+    expect(filterUsesSome(filter)).toBe(true);
+  });
+
+  it('detects _some nested inside an _and array', () => {
+    const filter = {
+      _and: [
+        { status: { _eq: 'published' } },
+        { tags: { _some: { name: { _icontains: 'news' } } } },
+      ],
+    };
+    expect(filterUsesSome(filter)).toBe(true);
+  });
+
+  it('returns false for plain field filters with no _some', () => {
+    const filter = {
+      _or: [
+        { title: { _icontains: 'hello' } },
+        { id: { _eq: 42 } },
+      ],
+    };
+    expect(filterUsesSome(filter)).toBe(false);
+  });
+
+  it('returns false for null and undefined', () => {
+    expect(filterUsesSome(null)).toBe(false);
+    expect(filterUsesSome(undefined)).toBe(false);
+  });
+
+  it('returns false for keys that merely start with _some (exact match only)', () => {
+    // Hypothetical key that is NOT the _some operator
+    const filter = { _something: { title: { _eq: 'x' } } };
+    expect(filterUsesSome(filter)).toBe(false);
+  });
+});

--- a/tests/unit/utils/listPickerFields.test.ts
+++ b/tests/unit/utils/listPickerFields.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { listPickerFields } from '@/utils/listPickerFields';
+import type { DescribeHop, HopInfo } from '@/utils/resolveRelationalPath';
+
+const makeDescribeHop =
+  (map: Record<string, HopInfo>): DescribeHop =>
+  (collection, field) =>
+    map[`${collection}.${field}`] ?? { kind: 'scalar' };
+
+const fieldsStore = (byCollection: Record<string, Array<{ field: string; name?: string }>>) => ({
+  getFieldsForCollection: (c: string) => byCollection[c] ?? [],
+});
+
+describe('listPickerFields', () => {
+  it('lists scalars as leaves and to-one/translations as drillable; omits to-many', () => {
+    const fs = fieldsStore({
+      service: [
+        { field: 'name', name: 'Name' },
+        { field: 'author' },
+        { field: 'translations' },
+        { field: 'tags' },
+        { field: '$thumbnail' },
+      ],
+    });
+    const hop = makeDescribeHop({
+      'service.name': { kind: 'scalar' },
+      'service.author': { kind: 'm2o', relatedCollection: 'users' },
+      'service.translations': { kind: 'translations', relatedCollection: 'service_translations' },
+      'service.tags': { kind: 'm2m', relatedCollection: 'service_tags' },
+    });
+    expect(listPickerFields('service', hop, fs)).toEqual([
+      { field: 'name', label: 'Name', drillable: false, relatedCollection: null, isTranslationsHop: false },
+      { field: 'author', label: 'author', drillable: true, relatedCollection: 'users', isTranslationsHop: false },
+      { field: 'translations', label: 'translations', drillable: true, relatedCollection: 'service_translations', isTranslationsHop: true },
+      // 'tags' (m2m) omitted; '$thumbnail' skipped
+    ]);
+  });
+
+  it('omits a relation without a related collection', () => {
+    const fs = fieldsStore({ x: [{ field: 'blocks' }] });
+    const hop = makeDescribeHop({ 'x.blocks': { kind: 'm2a', relatedCollection: null } });
+    expect(listPickerFields('x', hop, fs)).toEqual([]);
+  });
+
+  it('returns [] for an unknown/empty collection', () => {
+    expect(listPickerFields('nope', makeDescribeHop({}), fieldsStore({}))).toEqual([]);
+  });
+});

--- a/tests/unit/utils/renderM2ATemplate.test.ts
+++ b/tests/unit/utils/renderM2ATemplate.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { renderM2ATemplate } from '@/utils/renderM2ATemplate';
+import type { DescribeHop } from '@/utils/resolveRelationalPath';
 
 // Junction rows mirror the live orders.treatment shape: a `collection`
 // discriminator + a polymorphic `item` payload. `treatment` is the parent
@@ -210,6 +211,108 @@ describe('renderM2ATemplate', () => {
       expect(renderM2ATemplate(row, '{{code}}', itemField, discriminator, fieldName).trim()).toBe(
         ''
       );
+    });
+  });
+
+  // Deep relational paths — e.g. a translations relation INSIDE the M2A target —
+  // resolved via the schema-aware describeHop + the `:lang` suffix (issue #60 follow-up).
+  describe('deep relational paths via describeHop', () => {
+    const describeHop: DescribeHop = (collection, field) =>
+      collection === 'service' && field === 'translations'
+        ? {
+            kind: 'translations',
+            relatedCollection: 'service_translations',
+            languageField: 'languages_code',
+          }
+        : { kind: 'scalar' };
+
+    const row = {
+      collection: 'service',
+      item: {
+        translations: [
+          { languages_code: 'en-US', label: 'Maintenance (EN)' },
+          { languages_code: 'de-DE', label: 'Wartung (DE)' },
+        ],
+      },
+    };
+
+    it('resolves a nested translation in the language from the :lang suffix', () => {
+      expect(
+        renderM2ATemplate(
+          row,
+          '{{treatment.item:service.translations.label:de-DE}}',
+          itemField,
+          discriminator,
+          fieldName,
+          null,
+          { describeHop }
+        ).trim()
+      ).toBe('Wartung (DE)');
+      expect(
+        renderM2ATemplate(
+          row,
+          '{{treatment.item:service.translations.label:en-US}}',
+          itemField,
+          discriminator,
+          fieldName,
+          null,
+          { describeHop }
+        ).trim()
+      ).toBe('Maintenance (EN)');
+    });
+
+    it('falls back to the first translation row without a :lang suffix', () => {
+      expect(
+        renderM2ATemplate(
+          row,
+          '{{treatment.item:service.translations.label}}',
+          itemField,
+          discriminator,
+          fieldName,
+          null,
+          { describeHop }
+        ).trim()
+      ).toBe('Maintenance (EN)');
+    });
+
+    it('uses opts.language as the default when no :lang suffix is present', () => {
+      expect(
+        renderM2ATemplate(
+          row,
+          '{{treatment.item:service.translations.label}}',
+          itemField,
+          discriminator,
+          fieldName,
+          null,
+          { describeHop, language: 'de-DE' }
+        ).trim()
+      ).toBe('Wartung (DE)');
+    });
+
+    it('lets the token :lang suffix override opts.language', () => {
+      expect(
+        renderM2ATemplate(
+          row,
+          '{{treatment.item:service.translations.label:en-US}}',
+          itemField,
+          discriminator,
+          fieldName,
+          null,
+          { describeHop, language: 'de-DE' }
+        ).trim()
+      ).toBe('Maintenance (EN)');
+    });
+
+    it('renders empty for the nested translation without a resolver (back-compat)', () => {
+      expect(
+        renderM2ATemplate(
+          row,
+          '{{treatment.item:service.translations.label:de-DE}}',
+          itemField,
+          discriminator,
+          fieldName
+        ).trim()
+      ).toBe('');
     });
   });
 });

--- a/tests/unit/utils/renderM2ATemplate.test.ts
+++ b/tests/unit/utils/renderM2ATemplate.test.ts
@@ -315,4 +315,51 @@ describe('renderM2ATemplate', () => {
       ).toBe('');
     });
   });
+
+  describe('HTML stripping of resolved values', () => {
+    it('strips HTML tags from item field values', () => {
+      const row = {
+        collection: 'content_headline',
+        item: { description: '<p data-start="258">Seamless connection</p>' },
+      };
+      expect(
+        renderM2ATemplate(
+          row,
+          '{{item:content_headline.description}}',
+          itemField,
+          discriminator,
+          fieldName
+        )
+      ).toBe('Seamless connection');
+    });
+
+    it('decodes entities in resolved values', () => {
+      const row = { collection: 'service', item: { name: 'Fix &amp; Flip' } };
+      expect(
+        renderM2ATemplate(row, '{{item:service.name}}', itemField, discriminator, fieldName)
+      ).toBe('Fix & Flip');
+    });
+
+    it('strips HTML from junction-level and parent-row tokens too', () => {
+      const row = { collection: 'service', item: {}, note: '<b>urgent</b>' };
+      const parentRow = { context: '<em>Q3</em>' };
+      expect(
+        renderM2ATemplate(
+          row,
+          '{{treatment.note}} {{context}}',
+          itemField,
+          discriminator,
+          fieldName,
+          parentRow
+        )
+      ).toBe('urgent Q3');
+    });
+
+    it('leaves plain text values untouched', () => {
+      const row = { collection: 'service', item: { name: 'Installation (DE)' } };
+      expect(
+        renderM2ATemplate(row, '{{item:service.name}}', itemField, discriminator, fieldName)
+      ).toBe('Installation (DE)');
+    });
+  });
 });

--- a/tests/unit/utils/resolveRelationalPath.test.ts
+++ b/tests/unit/utils/resolveRelationalPath.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveRelationalPath,
+  collectTranslationLanguagePaths,
+  type HopInfo,
+} from '@/utils/resolveRelationalPath';
+
+// A mock schema: maps `collection.field` to its relational shape. In production
+// this comes from the relations/fields stores; here it's a plain table so the
+// resolver can be tested without Directus.
+const SCHEMA: Record<string, HopInfo> = {
+  'service.name': { kind: 'scalar' },
+  'service.translations': {
+    kind: 'translations',
+    relatedCollection: 'service_translations',
+    languageField: 'languages_code',
+  },
+  'service_translations.label': { kind: 'scalar' },
+
+  'partners_catalog.catalog_id': { kind: 'm2o', relatedCollection: 'catalog' },
+  'catalog.title': { kind: 'scalar' },
+  // A SECOND translations relation that uses a DIFFERENT language field name,
+  // to prove we honour the detected field rather than hardcoding languages_code.
+  'catalog.translations': {
+    kind: 'translations',
+    relatedCollection: 'catalog_translations',
+    languageField: 'lang',
+  },
+  'catalog_translations.title': { kind: 'scalar' },
+
+  'parent.children': { kind: 'o2m', relatedCollection: 'child' },
+  'child.name': { kind: 'scalar' },
+};
+
+const describeHop = (collection: string, field: string): HopInfo =>
+  SCHEMA[`${collection}.${field}`] ?? { kind: 'scalar' };
+
+describe('resolveRelationalPath', () => {
+  it('returns the data itself for an empty path', () => {
+    expect(resolveRelationalPath({ a: 1 }, '', 'service', describeHop, null)).toEqual({ a: 1 });
+  });
+
+  it('resolves a plain scalar field', () => {
+    const item = { name: 'Installation' };
+    expect(resolveRelationalPath(item, 'name', 'service', describeHop, null)).toBe('Installation');
+  });
+
+  it('descends an M2O chain (catalog_id.title)', () => {
+    const item = { catalog_id: { title: 'Premium' } };
+    expect(resolveRelationalPath(item, 'catalog_id.title', 'partners_catalog', describeHop, null)).toBe(
+      'Premium'
+    );
+  });
+
+  it('picks the translation row matching the active language', () => {
+    const item = {
+      translations: [
+        { languages_code: 'en-US', label: 'Maintenance' },
+        { languages_code: 'de-DE', label: 'Wartung' },
+      ],
+    };
+    expect(resolveRelationalPath(item, 'translations.label', 'service', describeHop, 'de-DE')).toBe(
+      'Wartung'
+    );
+  });
+
+  it('honours the DETECTED language field, not a hardcoded one', () => {
+    const item = {
+      translations: [
+        { lang: 'en-US', title: 'Catalog' },
+        { lang: 'de-DE', title: 'Katalog' },
+      ],
+    };
+    // catalog.translations uses `lang`, not `languages_code`.
+    expect(resolveRelationalPath(item, 'translations.title', 'catalog', describeHop, 'de-DE')).toBe(
+      'Katalog'
+    );
+  });
+
+  it('falls back to the first translation row when the language is absent', () => {
+    const item = {
+      translations: [
+        { languages_code: 'en-US', label: 'Maintenance' },
+        { languages_code: 'de-DE', label: 'Wartung' },
+      ],
+    };
+    expect(resolveRelationalPath(item, 'translations.label', 'service', describeHop, 'fr-FR')).toBe(
+      'Maintenance'
+    );
+  });
+
+  it('resolves an arbitrarily deep mixed path (M2O -> translations)', () => {
+    const item = {
+      catalog_id: {
+        translations: [
+          { lang: 'en-US', title: 'Premium' },
+          { lang: 'de-DE', title: 'Premium (DE)' },
+        ],
+      },
+    };
+    expect(
+      resolveRelationalPath(item, 'catalog_id.translations.title', 'partners_catalog', describeHop, 'de-DE')
+    ).toBe('Premium (DE)');
+  });
+
+  it('takes the first element for a plain to-many hop (documented boundary)', () => {
+    const item = { children: [{ name: 'First' }, { name: 'Second' }] };
+    expect(resolveRelationalPath(item, 'children.name', 'parent', describeHop, null)).toBe('First');
+  });
+
+  it('skips $-prefixed virtual segments', () => {
+    const item = { name: 'X' };
+    expect(resolveRelationalPath(item, '$thumbnail.name', 'service', describeHop, null)).toBe('X');
+  });
+
+  it('is null/undefined safe (no throw)', () => {
+    expect(resolveRelationalPath(null, 'translations.label', 'service', describeHop, 'de-DE')).toBeUndefined();
+    expect(resolveRelationalPath({}, 'translations.label', 'service', describeHop, 'de-DE')).toBeUndefined();
+    expect(
+      resolveRelationalPath({ translations: null }, 'translations.label', 'service', describeHop, 'de-DE')
+    ).toBeUndefined();
+    expect(resolveRelationalPath('scalar', 'foo', 'service', describeHop, null)).toBeUndefined();
+  });
+
+  it('returns undefined for a missing field rather than throwing', () => {
+    expect(resolveRelationalPath({ name: 'X' }, 'nope', 'service', describeHop, null)).toBeUndefined();
+  });
+});
+
+describe('collectTranslationLanguagePaths', () => {
+  it('returns the language-field sub-path for a translations hop', () => {
+    expect(collectTranslationLanguagePaths('translations.label', 'service', describeHop)).toEqual([
+      'translations.languages_code',
+    ]);
+  });
+
+  it('uses the detected language field (custom name) and handles depth', () => {
+    expect(
+      collectTranslationLanguagePaths('catalog_id.translations.title', 'partners_catalog', describeHop)
+    ).toEqual(['catalog_id.translations.lang']);
+  });
+
+  it('returns [] when the path crosses no translations relation', () => {
+    expect(
+      collectTranslationLanguagePaths('catalog_id.title', 'partners_catalog', describeHop)
+    ).toEqual([]);
+    expect(collectTranslationLanguagePaths('name', 'service', describeHop)).toEqual([]);
+  });
+});

--- a/tests/unit/utils/resolveRelationalPath.test.ts
+++ b/tests/unit/utils/resolveRelationalPath.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   resolveRelationalPath,
   collectTranslationLanguagePaths,
+  splitPathSegments,
   type HopInfo,
 } from '@/utils/resolveRelationalPath';
 
@@ -145,5 +146,32 @@ describe('collectTranslationLanguagePaths', () => {
       collectTranslationLanguagePaths('catalog_id.title', 'partners_catalog', describeHop)
     ).toEqual([]);
     expect(collectTranslationLanguagePaths('name', 'service', describeHop)).toEqual([]);
+  });
+});
+
+describe('splitPathSegments', () => {
+  it('splits a dotted path into segments', () => {
+    expect(splitPathSegments('translations.label')).toEqual(['translations', 'label']);
+  });
+
+  it('returns a single-segment array for a plain field', () => {
+    expect(splitPathSegments('name')).toEqual(['name']);
+  });
+
+  it('trims whitespace around segments', () => {
+    expect(splitPathSegments(' a . b ')).toEqual(['a', 'b']);
+  });
+
+  it('drops empty segments (leading/trailing/double dots)', () => {
+    expect(splitPathSegments('.a..b.')).toEqual(['a', 'b']);
+  });
+
+  it('drops $-virtual segments like $thumbnail', () => {
+    expect(splitPathSegments('image.$thumbnail.title')).toEqual(['image', 'title']);
+  });
+
+  it('returns [] for an empty or all-virtual path', () => {
+    expect(splitPathSegments('')).toEqual([]);
+    expect(splitPathSegments('$thumbnail')).toEqual([]);
   });
 });

--- a/tests/unit/utils/searchSync.test.ts
+++ b/tests/unit/utils/searchSync.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeIncomingSearch, normalizeOutgoingSearch } from '@/utils/searchSync';
+
+describe('normalizeIncomingSearch', () => {
+  it('maps null/undefined to empty string', () => {
+    expect(normalizeIncomingSearch(null)).toBe('');
+    expect(normalizeIncomingSearch(undefined)).toBe('');
+  });
+  it('passes a real query through unchanged', () => {
+    expect(normalizeIncomingSearch('abc')).toBe('abc');
+    expect(normalizeIncomingSearch('')).toBe('');
+  });
+});
+
+describe('normalizeOutgoingSearch', () => {
+  it('collapses empty/whitespace to null', () => {
+    expect(normalizeOutgoingSearch('')).toBe(null);
+    expect(normalizeOutgoingSearch('   ')).toBe(null);
+  });
+  it('keeps a real query (untrimmed)', () => {
+    expect(normalizeOutgoingSearch('abc')).toBe('abc');
+    expect(normalizeOutgoingSearch(' a ')).toBe(' a ');
+  });
+});

--- a/tests/unit/utils/stripHtml.test.ts
+++ b/tests/unit/utils/stripHtml.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { stripHtml } from '@/utils/stripHtml';
+// NOTE: happy-dom's tokenizer mishandles an unspaced "<" before a digit ("i<3u");
+// only assert on inputs that behave identically in browsers and happy-dom.
+
+describe('stripHtml', () => {
+  it('strips simple paragraph tags', () => {
+    expect(stripHtml('<p>Hello</p>')).toBe('Hello');
+  });
+
+  it('strips nested tags and attributes', () => {
+    expect(stripHtml('<div><span style="color: red;">Nested</span></div>')).toBe('Nested');
+    expect(stripHtml('<p data-start="258" data-end="403">Seamless connection</p>')).toBe(
+      'Seamless connection'
+    );
+  });
+
+  it('survives a ">" inside a quoted attribute (regex strippers break here)', () => {
+    expect(stripHtml('<a title="a>b">link</a>')).toBe('link');
+  });
+
+  it('keeps a word boundary where tags are dropped', () => {
+    expect(stripHtml('Line 1<br/>Line 2')).toBe('Line 1 Line 2');
+    expect(stripHtml('<p>First</p><p>Second</p>')).toBe('First Second');
+  });
+
+  it('decodes the basic entities', () => {
+    expect(stripHtml('Cats &amp; Dogs')).toBe('Cats & Dogs');
+    expect(stripHtml('1 &lt; 2 &gt; 0')).toBe('1 < 2 > 0');
+    expect(stripHtml('Say &quot;Hi&quot;')).toBe('Say "Hi"');
+    expect(stripHtml('It&#39;s working')).toBe("It's working");
+  });
+
+  it('decodes entities beyond the basic five (real WYSIWYG output)', () => {
+    expect(stripHtml('a&nbsp;b')).toBe('a b');
+    expect(stripHtml('it&#8217;s')).toBe('it’s');
+  });
+
+  it('does not double-decode (&amp;lt; stays a literal &lt;)', () => {
+    expect(stripHtml('&amp;lt;')).toBe('&lt;');
+  });
+
+  it('collapses whitespace and trims', () => {
+    expect(stripHtml('  Hello\n\n  World\t!  ')).toBe('Hello World !');
+  });
+
+  it('returns empty string for null/undefined/empty', () => {
+    expect(stripHtml(null)).toBe('');
+    expect(stripHtml(undefined)).toBe('');
+    expect(stripHtml('')).toBe('');
+  });
+
+  it('leaves plain text, numbers and a lone "<" untouched', () => {
+    expect(stripHtml('Installation (DE)')).toBe('Installation (DE)');
+    expect(stripHtml('123.45')).toBe('123.45');
+    expect(stripHtml('a < b')).toBe('a < b');
+  });
+
+  it('drops script/style content entirely, like the native display', () => {
+    expect(stripHtml('Total <script>track()</script> 42')).toBe('Total 42');
+    expect(stripHtml('A<style>.x { color: red; }</style>B')).toBe('A B');
+  });
+
+  it('stringifies non-string scalars', () => {
+    expect(stripHtml(42)).toBe('42');
+    expect(stripHtml(true)).toBe('true');
+  });
+});

--- a/tests/unit/utils/warnOnce.test.ts
+++ b/tests/unit/utils/warnOnce.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { warnOnce, __resetWarnOnce } from '@/utils/warnOnce';
+
+describe('warnOnce', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    __resetWarnOnce();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('emits a given message only once', () => {
+    warnOnce('dup');
+    warnOnce('dup');
+    warnOnce('dup');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith('dup');
+  });
+
+  it('treats distinct messages independently', () => {
+    warnOnce('a');
+    warnOnce('b');
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('__resetWarnOnce clears the dedupe cache', () => {
+    warnOnce('again');
+    __resetWarnOnce();
+    warnOnce('again');
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
> **Hinweis:** Fortführung von #66. Der Branch wurde umbenannt zu `feature/issue-65-m2a-nested-translations` (Issue-Nummer im Branch-Namen); GitHubs Head-Branch-Rename hat #66 dabei automatisch geschlossen. Code, Commits und CI sind identisch — dieser PR ersetzt #66.

Closes #65

## Summary

M2A column templates now resolve deep relational paths — including a `translations` relation stored inside the target collection, e.g. `{{item:service.translations.label:de-DE}}` (M2A → target → translations → value). Resolution is generic and schema-driven via the relations store, so it scales to arbitrary depth (M2O chains, files, nested translations) without per-level special-casing. Requested by @Abdallah-Awwad as a follow-up to #60.

### Added
- Deep relational path resolution in M2A templates (`resolveRelationalPath` + `describeHop`)
- Per-relation language-field detection (read from `junction_field`, not hardcoded)
- Language selection via optional `:lang` token suffix; without it the current user's language is used, falling back to the first available row

### Fixed / Hardening (from a multi-agent audit of this branch)
- Invalid deep template fields no longer blank the view: every segment of every relational token (M2A item/junction/parent, M2M, M2O/O2M/files) is validated against the schema before the request; invalid tokens are dropped with a deduplicated `console.warn` instead of 403'ing the whole fetch
- HTML translation values render as plain text in M2A cells (DOMParser-based strip, matching the native formatted-value display incl. script/style content removal)
- Nested to-many relations inside M2A items are fetched unbounded (`deep[<field>][item:<col>][<rel>][_limit]=-1` — API code path verified against Directus source v9 → main and live at depth 2)
- The native header search now drives the layout (was inert; only the toolbar search filtered); native input mirrors into the layout's intelligent `_or` filter. Reverse mirroring is impossible: the layout wrapper swallows `update:search` (verified in core source and deployed bundle)
- Item count no longer double-applies the search, and counts over to-many search filters use `countDistinct(pk)` (with `count(*)` fallback) so join products no longer inflate totals
- Exactly one items+count request pair per change: content-fingerprint watcher + coalescing single-flight runner (bookmark cold load fired 3 identical pairs before; template edits fired 2; every layout-options write refetched needlessly). Overlapping responses can no longer land out of order
- Removed two provably dead watchers and fixed a window-event listener leak

## Verification
- 365/365 unit tests (≈120 added on this branch), `vue-tsc`, ESLint `--max-warnings=0`, Prettier — all green
- Multi-agent audit (static review × 3, adversarial verification per finding) plus ~25 Playwright runtime scenarios against a live Directus 11.11.0: language semantics (suffix / user language / first-row fallback, proven via temporary user-language switch), generalization to a second M2A schema, graceful degradation for invalid tokens on every branch, single-pair fetch contract (cold load, sort, pagination, UI template edit, layout-options writes = zero), native/toolbar search parity incl. count consistency over translations, and regression sweeps over tags M2M, per-language translation columns, bookmarks and row navigation

## Notes
- The header search pill's own result badge is computed by Directus core with native search semantics and can undercount translation-only matches; the table and its pagination use the layout's filter and are authoritative (documented in CHANGELOG)
- `CHANGELOG.md` carries the full v0.6.0 notes; `package.json` is already bumped to 0.6.0
