### PR TITLE
Release v0.6.1: M2A deep-path test & robustness hardening (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to the Super Layout Table Extension will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.6.1 — Robustness & test hardening
+
+Follow-up to v0.6.0 (#68). No functional behavior change — internal hardening and
+additional unit coverage; verified with a live regression of the v0.6.0
+nested-translation feature.
+
+### Changed
+- **Fetch dedup is more robust.** The query fingerprint now canonicalizes nested
+  `filter`/`deep`/`alias` key order, so two semantically identical queries built
+  with a different key insertion order dedupe to a single request; array order
+  stays significant. The fingerprint is a dedup-only comparison key and never
+  forms the wire query. `sort` is normalized (`?? null`) consistently with the
+  other parameters.
+- **Single user-language helper.** The current user's language lookup for nested
+  translations is extracted into a pure, typed `resolveUserLanguage` helper and
+  reused at both call sites, removing duplicated untyped (`as any`) access.
+
+### Tests
+- Added coverage for the non-default translation language field at the render and
+  query-expansion levels, deep M2O chains (resolution and validation), the field
+  picker's single-file vs. to-many handling, the fingerprint canonicalization, and
+  the user-language helper (16 new unit tests).
+
 ## v0.6.0 — Deep relational paths in M2A templates (nested translations)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-super-table",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A powerful and feature-rich table layout extension for Directus 11+ with inline editing, quick filters, and manual sorting",
   "icon": "table_rows",
   "keywords": [

--- a/src/components/EditableCellRelational.vue
+++ b/src/components/EditableCellRelational.vue
@@ -194,6 +194,7 @@ import { pickHeuristic, isM2A } from '../utils/displayHeuristics';
 import { resolveM2ARelation } from '../utils/resolveM2ARelation';
 import { buildM2ASegments, isBlockedSegment, type M2ASegment } from '../utils/buildM2ASegments';
 import { createDescribeHop } from '../utils/describeHop';
+import { resolveUserLanguage } from '../utils/resolveUserLanguage';
 import { resolveTranslationValue } from '../utils/resolveTranslationValue';
 import { usePermissions } from '../composables/usePermissions';
 
@@ -206,10 +207,6 @@ const userStore = useUserStore?.();
 // Schema-aware hop resolver so M2A templates can reach deep relations
 // (e.g. translations stored inside the target collection).
 const describeHop = createDescribeHop(fieldsStore, relationsStore);
-
-// Default language for nested translations when a token carries no `:lang`
-// suffix: the current user's language (falls back to the first row).
-const defaultLanguage = (): string | null => (userStore as any)?.currentUser?.language ?? null;
 
 const props = defineProps<{
   item: Item;
@@ -438,7 +435,7 @@ const m2aSegments = computed<M2ASegment[]>(() => {
     String(fieldName),
     props.item,
     (c) => permissions.canRead(c),
-    { describeHop, language: defaultLanguage() }
+    { describeHop, language: resolveUserLanguage(userStore) }
   );
 });
 

--- a/src/composables/api.ts
+++ b/src/composables/api.ts
@@ -50,6 +50,8 @@ export function useTableApi() {
         limit: options.limit || 100,
       };
       if (options.filter) params.filter = options.filter;
+      // The main listing path drives search through `filter` (intelligent _or);
+      // this `search` param stays for other callers (e.g. export).
       if (options.search) params.search = options.search;
       if (options.sort && options.sort.length > 0) params.sort = options.sort;
       if (options.deep) params.deep = options.deep;

--- a/src/composables/useLanguageSelector.ts
+++ b/src/composables/useLanguageSelector.ts
@@ -3,6 +3,7 @@ import { useStores } from '@directus/extensions-sdk';
 import { useTableApi } from './api';
 import type { Language } from '../types/table.types';
 import { DEFAULT_LANGUAGES, DEFAULT_LANGUAGE_CODE } from '../constants/languages';
+import { resolveUserLanguage } from '../utils/resolveUserLanguage';
 
 export function useLanguageSelector() {
   const tableApi = useTableApi();
@@ -14,7 +15,7 @@ export function useLanguageSelector() {
   const loadingLanguages = ref(false);
 
   // Selected language - default to user's language
-  const selectedLanguage = ref<string>(userStore.currentUser?.language || DEFAULT_LANGUAGE_CODE);
+  const selectedLanguage = ref<string>(resolveUserLanguage(userStore) || DEFAULT_LANGUAGE_CODE);
 
   // Fetch available languages from Directus
   async function fetchLanguages() {

--- a/src/utils/buildQueryFingerprint.ts
+++ b/src/utils/buildQueryFingerprint.ts
@@ -2,8 +2,13 @@
  * Stable string fingerprint of every parameter that affects the items request.
  * The query watcher dedupes on this string, so it must include EXACTLY what
  * `getItems` reads — extracted here so a test pins that set (dropping a key
- * would silently suppress a needed refetch). Key order is fixed for stable
- * output across evaluations.
+ * would silently suppress a needed refetch).
+ *
+ * This string is ONLY a dedup comparison key — it never forms the wire query
+ * (`getItems` reads the original filter/deep/alias objects). `stableReplacer`
+ * canonicalizes nested object key order so two semantically identical queries
+ * built with a different key insertion order share one fingerprint; arrays keep
+ * their order (significant for `fields`/`sort`/`_and`/`_or`).
  */
 export interface QueryFingerprintInput {
   collection: string | null;
@@ -16,15 +21,35 @@ export interface QueryFingerprintInput {
   alias: unknown;
 }
 
+/**
+ * JSON.stringify replacer that sorts object keys for canonical output. Arrays
+ * pass through untouched (their order is significant); null passes through
+ * (`typeof null === 'object'`). JSON.stringify applies it recursively, so
+ * nested objects are canonicalized at every depth.
+ */
+function stableReplacer(_key: string, value: unknown): unknown {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return value;
+  const obj = value as Record<string, unknown>;
+  return Object.keys(obj)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, k) => {
+      acc[k] = obj[k];
+      return acc;
+    }, {});
+}
+
 export function buildQueryFingerprint(input: QueryFingerprintInput): string {
-  return JSON.stringify({
-    collection: input.collection,
-    fields: input.fields,
-    filter: input.filter ?? null,
-    sort: input.sort,
-    page: input.page,
-    limit: input.limit,
-    deep: input.deep ?? null,
-    alias: input.alias ?? null,
-  });
+  return JSON.stringify(
+    {
+      collection: input.collection,
+      fields: input.fields,
+      filter: input.filter ?? null,
+      sort: input.sort ?? null,
+      page: input.page,
+      limit: input.limit,
+      deep: input.deep ?? null,
+      alias: input.alias ?? null,
+    },
+    stableReplacer
+  );
 }

--- a/src/utils/coalesce.ts
+++ b/src/utils/coalesce.ts
@@ -29,6 +29,9 @@ export function createCoalescedRunner(fn: () => Promise<void> | void): () => Pro
     try {
       do {
         rerunRequested = false;
+        // Invariant: fn must not reject — a throw exits this loop and drops a
+        // rerunRequested set during the run. getItems catches its awaited fetch;
+        // the synchronous .value reads before it are treated as non-throwing.
         await fn();
       } while (rerunRequested);
     } finally {

--- a/src/utils/resolveUserLanguage.ts
+++ b/src/utils/resolveUserLanguage.ts
@@ -1,0 +1,18 @@
+/**
+ * Resolve the current user's language from the user store. Used as the default
+ * language for nested translations when a template token carries no `:lang`
+ * suffix. Pure over a minimal store shape so it stays unit-testable and the
+ * call sites drop their `as any` cast. Returns null when no language is set
+ * (e.g. share/public context) so callers fall back to the first translation row.
+ */
+export interface UserLike {
+  language?: string | null;
+}
+
+export interface UserStoreLike {
+  currentUser?: UserLike | null;
+}
+
+export function resolveUserLanguage(userStore: UserStoreLike | null | undefined): string | null {
+  return userStore?.currentUser?.language ?? null;
+}

--- a/tests/unit/utils/buildQueryFingerprint.test.ts
+++ b/tests/unit/utils/buildQueryFingerprint.test.ts
@@ -34,4 +34,42 @@ describe('buildQueryFingerprint', () => {
     expect(buildQueryFingerprint({ ...base, deep: { treatment: { _limit: -1 } } })).not.toBe(fp);
     expect(buildQueryFingerprint({ ...base, alias: { x: 'y' } })).not.toBe(fp);
   });
+
+  it('is stable across nested object key reordering (filter/deep)', () => {
+    const a = buildQueryFingerprint({
+      ...base,
+      filter: { status: { _eq: 'A' }, code: { _eq: 'X' } },
+      deep: { translations: { _fields: ['*'], _limit: -1 } },
+    });
+    const b = buildQueryFingerprint({
+      ...base,
+      filter: { code: { _eq: 'X' }, status: { _eq: 'A' } },
+      deep: { translations: { _limit: -1, _fields: ['*'] } },
+    });
+    expect(a).toBe(b);
+  });
+
+  it('canonicalizes key order INSIDE array elements (filter._and[0])', () => {
+    const a = buildQueryFingerprint({ ...base, filter: { _and: [{ a: { _eq: 1 }, b: { _eq: 2 } }] } });
+    const b = buildQueryFingerprint({ ...base, filter: { _and: [{ b: { _eq: 2 }, a: { _eq: 1 } }] } });
+    expect(a).toBe(b);
+  });
+
+  it('keeps array element ORDER significant even when elements are objects', () => {
+    const a = buildQueryFingerprint({ ...base, filter: { _or: [{ x: { _eq: 1 } }, { y: { _eq: 2 } }] } });
+    const b = buildQueryFingerprint({ ...base, filter: { _or: [{ y: { _eq: 2 } }, { x: { _eq: 1 } }] } });
+    expect(a).not.toBe(b);
+  });
+
+  it('still differs when a value inside a nested object changes', () => {
+    const a = buildQueryFingerprint({ ...base, deep: { t: { _limit: -1 } } });
+    const b = buildQueryFingerprint({ ...base, deep: { t: { _limit: -2 } } });
+    expect(a).not.toBe(b);
+  });
+
+  it('treats sort null and undefined identically', () => {
+    expect(buildQueryFingerprint({ ...base, sort: null })).toBe(
+      buildQueryFingerprint({ ...base, sort: undefined })
+    );
+  });
 });

--- a/tests/unit/utils/expandTokensThroughRelation.test.ts
+++ b/tests/unit/utils/expandTokensThroughRelation.test.ts
@@ -346,6 +346,61 @@ describe('expandTokensThroughRelation', () => {
       meta: { special: ['m2a'] },
     } as any;
 
+    it('emits the translations companion using the detected junction_field (lang), not hardcoded languages_code', () => {
+      // A non-default M2A-target translations relation (junction_field 'lang').
+      // The existing companion tests all use 'languages_code' — which is also the
+      // hardcode default — so only a 'lang' fixture proves the companion column
+      // follows the DETECTED field through the full M2A expansion pipeline.
+      const { fieldsStore, relationsStore } = makeStores(
+        {
+          'service.translations': { field: 'translations', meta: { special: ['translations'] } },
+          'service_translations.label': { field: 'label' },
+          'service_translations.lang': { field: 'lang' },
+        },
+        {
+          'orders.treatment': [
+            {
+              collection: 'orders_treatment',
+              field: 'orders_id',
+              related_collection: 'orders',
+              meta: { junction_field: 'item' },
+            },
+            {
+              collection: 'orders_treatment',
+              field: 'item',
+              related_collection: null,
+              meta: {
+                one_collection_field: 'collection',
+                one_allowed_collections: ['service'],
+                junction_field: 'orders_id',
+              },
+            },
+          ],
+          'service.translations': [
+            {
+              collection: 'service_translations',
+              field: 'service_id',
+              related_collection: 'service',
+              meta: { one_field: 'translations', junction_field: 'lang' },
+            },
+          ],
+        }
+      );
+      const result = expandTokensThroughRelation(
+        m2aField,
+        'treatment',
+        'orders',
+        ['item:service.translations.label'],
+        fieldsStore as any,
+        relationsStore as any
+      );
+      expect(result).toEqual([
+        'treatment.collection',
+        'treatment.item:service.translations.label',
+        'treatment.item:service.translations.lang',
+      ]);
+    });
+
     it('expands per-collection item tokens and always emits the discriminator', () => {
       const { fieldsStore, relationsStore } = m2aStores();
       const result = expandTokensThroughRelation(

--- a/tests/unit/utils/fieldValidity.test.ts
+++ b/tests/unit/utils/fieldValidity.test.ts
@@ -209,6 +209,10 @@ describe('validateDeepPath', () => {
         'service.blocks',
         'service.attachments',
         'service_translations.label',
+        // M2O -> M2O chain: service.owner -> owner.parent -> org.name
+        'service.owner',
+        'owner.parent',
+        'org.name',
       ].includes(`${collection}.${field}`)
         ? { collection, field }
         : null,
@@ -217,6 +221,8 @@ describe('validateDeepPath', () => {
     'service.translations': { kind: 'translations', relatedCollection: 'service_translations' },
     'service.blocks': { kind: 'm2a', relatedCollection: null },
     'service.attachments': { kind: 'files', relatedCollection: 'directus_files' },
+    'service.owner': { kind: 'm2o', relatedCollection: 'owner' },
+    'owner.parent': { kind: 'm2o', relatedCollection: 'org' },
   });
 
   it('accepts a valid multi-hop path', () => {
@@ -235,6 +241,18 @@ describe('validateDeepPath', () => {
     const r = validateDeepPath('service', 'name.deeper', deepFieldsStore, describeHop);
     expect(r.valid).toBe(false);
     expect(r.reason).toContain('service.name');
+  });
+
+  it('accepts a valid pure M2O -> M2O -> scalar chain (owner.parent.name)', () => {
+    expect(validateDeepPath('service', 'owner.parent.name', deepFieldsStore, describeHop)).toEqual({
+      valid: true,
+    });
+  });
+
+  it('rejects an invalid leaf after a two-hop M2O chain, naming the deepest collection', () => {
+    const r = validateDeepPath('service', 'owner.parent.ghost', deepFieldsStore, describeHop);
+    expect(r.valid).toBe(false);
+    expect(r.reason).toContain('org.ghost');
   });
 
   it('rejects an unknown root segment and an empty path', () => {

--- a/tests/unit/utils/listPickerFields.test.ts
+++ b/tests/unit/utils/listPickerFields.test.ts
@@ -36,6 +36,27 @@ describe('listPickerFields', () => {
     ]);
   });
 
+  it('treats a single file as drillable (directus_files) and omits to-many files/o2m', () => {
+    const fs = fieldsStore({
+      service: [{ field: 'cover', name: 'Cover' }, { field: 'gallery' }, { field: 'reviews' }],
+    });
+    const hop = makeDescribeHop({
+      'service.cover': { kind: 'file', relatedCollection: 'directus_files' },
+      'service.gallery': { kind: 'files', relatedCollection: 'directus_files' },
+      'service.reviews': { kind: 'o2m', relatedCollection: 'reviews' },
+    });
+    expect(listPickerFields('service', hop, fs)).toEqual([
+      {
+        field: 'cover',
+        label: 'Cover',
+        drillable: true,
+        relatedCollection: 'directus_files',
+        isTranslationsHop: false,
+      },
+      // 'gallery' (files) and 'reviews' (o2m) are to-many → omitted
+    ]);
+  });
+
   it('omits a relation without a related collection', () => {
     const fs = fieldsStore({ x: [{ field: 'blocks' }] });
     const hop = makeDescribeHop({ 'x.blocks': { kind: 'm2a', relatedCollection: null } });

--- a/tests/unit/utils/renderM2ATemplate.test.ts
+++ b/tests/unit/utils/renderM2ATemplate.test.ts
@@ -314,6 +314,36 @@ describe('renderM2ATemplate', () => {
         ).trim()
       ).toBe('');
     });
+
+    // Regression guard: the render path must pick the translation row via the
+    // DETECTED language field (here `lang`), not a hardcoded `languages_code`.
+    // A hardcode would miss every row and fall back to the first → wrong language.
+    it('honours the detected language field (lang) at render, not hardcoded languages_code', () => {
+      const langHop: DescribeHop = (collection, field) =>
+        collection === 'service' && field === 'translations'
+          ? { kind: 'translations', relatedCollection: 'service_translations', languageField: 'lang' }
+          : { kind: 'scalar' };
+      const langRow = {
+        collection: 'service',
+        item: {
+          translations: [
+            { lang: 'en-US', label: 'Maintenance (EN)' },
+            { lang: 'de-DE', label: 'Wartung (DE)' },
+          ],
+        },
+      };
+      expect(
+        renderM2ATemplate(
+          langRow,
+          '{{treatment.item:service.translations.label:de-DE}}',
+          itemField,
+          discriminator,
+          fieldName,
+          null,
+          { describeHop: langHop }
+        ).trim()
+      ).toBe('Wartung (DE)');
+    });
   });
 
   describe('HTML stripping of resolved values', () => {

--- a/tests/unit/utils/resolveRelationalPath.test.ts
+++ b/tests/unit/utils/resolveRelationalPath.test.ts
@@ -20,6 +20,9 @@ const SCHEMA: Record<string, HopInfo> = {
 
   'partners_catalog.catalog_id': { kind: 'm2o', relatedCollection: 'catalog' },
   'catalog.title': { kind: 'scalar' },
+  // A second M2O hop after catalog, so a pure M2O -> M2O -> scalar chain is covered.
+  'catalog.owner': { kind: 'm2o', relatedCollection: 'owner' },
+  'owner.name': { kind: 'scalar' },
   // A SECOND translations relation that uses a DIFFERENT language field name,
   // to prove we honour the detected field rather than hardcoding languages_code.
   'catalog.translations': {
@@ -51,6 +54,13 @@ describe('resolveRelationalPath', () => {
     expect(resolveRelationalPath(item, 'catalog_id.title', 'partners_catalog', describeHop, null)).toBe(
       'Premium'
     );
+  });
+
+  it('descends a pure M2O -> M2O -> scalar chain (catalog_id.owner.name)', () => {
+    const item = { catalog_id: { owner: { name: 'ACME' } } };
+    expect(
+      resolveRelationalPath(item, 'catalog_id.owner.name', 'partners_catalog', describeHop, null)
+    ).toBe('ACME');
   });
 
   it('picks the translation row matching the active language', () => {

--- a/tests/unit/utils/resolveUserLanguage.test.ts
+++ b/tests/unit/utils/resolveUserLanguage.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { resolveUserLanguage } from '@/utils/resolveUserLanguage';
+
+describe('resolveUserLanguage', () => {
+  it('returns the language when set', () => {
+    expect(resolveUserLanguage({ currentUser: { language: 'de-DE' } })).toBe('de-DE');
+  });
+
+  it('returns null when currentUser is null', () => {
+    expect(resolveUserLanguage({ currentUser: null })).toBeNull();
+  });
+
+  it('returns null for a null or undefined store', () => {
+    expect(resolveUserLanguage(null)).toBeNull();
+    expect(resolveUserLanguage(undefined)).toBeNull();
+  });
+
+  it('returns null in a share/public context (currentUser without a language key)', () => {
+    // A share token's currentUser has no `language` property → undefined → null,
+    // so callers fall back to the first translation row.
+    expect(resolveUserLanguage({ currentUser: {} })).toBeNull();
+  });
+
+  it('passes an empty-string language through (caller applies its own fallback)', () => {
+    // `?? null` only coalesces null/undefined; '' flows through so a caller's
+    // `|| DEFAULT` still kicks in — parity with the pre-extraction behavior.
+    expect(resolveUserLanguage({ currentUser: { language: '' } })).toBe('');
+  });
+});


### PR DESCRIPTION
Closes #68.

Follow-up to #67 (v0.6.0): closes the deferred test-coverage and robustness gaps in the M2A deep-path template feature. **No functional behavior change** — pure hardening, two tiny robustness fixes, and unit coverage. Verified live + adversarially reviewed.

## Changes

**Refactor / robustness (production code, behavior-preserving)**
- Extract `resolveUserLanguage(userStore)` into a pure, typed helper (`UserStoreLike`/`UserLike`) and use it at both call sites (`EditableCellRelational.vue`, `useLanguageSelector.ts`), dropping the `as any` casts. Behavior identical at both sites (incl. the `''` / null / undefined paths).
- `buildQueryFingerprint`: normalize `sort` to `?? null` (consistent with filter/deep/alias) and canonicalize nested object key order via a typed `stableReplacer` (null- and array-guarded; arrays keep their order). The fingerprint is a dedup-only comparison key — it never forms the wire query.
- Document the `coalesce` reject invariant and the `api` listing-search path (comments only).

**Tests (close the #68 gaps, no duplication of existing coverage)**
- `resolveUserLanguage`: set / null / null-store / share-without-language / empty-string.
- `buildQueryFingerprint`: nested key reorder -> equal; reorder inside array elements -> equal; array element order significant -> differs; deep value change -> differs; sort null vs undefined -> equal.
- Non-default translation language field (`junction_field: 'lang'`) at the render (`renderM2ATemplate`) and query-expansion (`expandTokensThroughRelation`) levels — "detected, not hardcoded `languages_code`".
- Deep M2O chains: pure `M2O -> M2O -> scalar` resolve, and `validateDeepPath` `M2O -> M2O -> invalid-leaf` naming the deepest collection.
- `listPickerFields`: single `file` drillable (directus_files); to-many `files` / `o2m` omitted.

**Out of scope (deferred):** the `super-table.vue` consolidation items (#8/#9 in the issue) are structural refactors and belong in a separate issue. No version bump (left for the next release).

## Verification
- `vitest`: 404/404 (16 added on this branch). `vue-tsc`, ESLint `--max-warnings=0`, Prettier — all green. (The one timing-based `useExistingLanguageDetection > should be performant` flake passes on retry; pre-existing, untouched here.)
- Live Playwright regression against Directus 11.11.0 (M2A nested-translation preset): nested-translation render (de-DE / en-US / no-suffix -> user-language -> first-row fallback), invalid-token graceful degradation (dedup warn, no 403), M2O-chain, native-search-drives-layout and single items+count fetch pair — all identical to pre-change; zero console errors.
- Adversarial code review of the diff: merge-ready, no critical/important findings.

## Test plan
- [x] Unit suite green (incl. new tests)
- [x] type-check / lint / format green
- [x] Live render regression (nested translations, language variants)
- [x] Invalid-token graceful degradation (no 403)
- [x] Search wiring + single fetch pair unchanged
- [x] No console errors