### PR TITLE
Release v0.6.2: unified deep-build, lifecycle consolidation & bare-translation display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to the Super Layout Table Extension will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.7.0 — Unified deep-build, lifecycle consolidation & bare-translation display
+
+Follow-up to v0.6.1 (#70). Consolidates the `super-table.vue` orchestrator and
+unifies the `deep`-query construction onto a single schema-driven classifier.
+
+### Changed (behavior)
+- **To-many relations are fetched completely.** First-level `o2m`/`m2m`/`files`
+  columns (and bare `translations`) are now fetched unbounded
+  (`deep[<field>][_limit]=-1`), consistent with the nested-M2A policy — previously
+  they were capped at the server's default page size (silently truncating the
+  displayed, comma-joined list) or not fetched at all. A column on a very large
+  to-many relation now fetches every row: the inherent cost of displaying it fully.
+- **`deep` is built by one schema-driven classifier** (`buildDeep`), so first-level
+  and nested entries share a single source of truth (`describeHop`). The previous
+  ad-hoc `special.includes(...)` first-level branch is gone.
+
+### Added
+- **Bare `translations` columns render the active-language value** instead of raw
+  JSON. The active-language row (current user's language, falling back to the first
+  available) is rendered through the column's configured template or a heuristic
+  field (`description`/`title`/…), with HTML stripped.
+
+### Internal
+- The two `onMounted`/`onUnmounted` blocks in `super-table.vue` are merged into a
+  single auditable pair; `pickTranslationRow` is exported for reuse. ~130 net lines
+  removed from the orchestrator. 431/431 unit tests, `vue-tsc`, ESLint, Prettier
+  all green; verified live across 13 collections + the M2A/translation flows.
+
 ## v0.6.1 — Robustness & test hardening
 
 Follow-up to v0.6.0 (#68). No functional behavior change — internal hardening and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Super Layout Table Extension will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.7.0 — Unified deep-build, lifecycle consolidation & bare-translation display
+## v0.6.2 — Unified deep-build, lifecycle consolidation & bare-translation display
 
 Follow-up to v0.6.1 (#70). Consolidates the `super-table.vue` orchestrator and
 unifies the `deep`-query construction onto a single schema-driven classifier.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-super-table",
-  "version": "0.7.0",
+  "version": "0.6.2",
   "description": "A powerful and feature-rich table layout extension for Directus 11+ with inline editing, quick filters, and manual sorting",
   "icon": "table_rows",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-super-table",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "A powerful and feature-rich table layout extension for Directus 11+ with inline editing, quick filters, and manual sorting",
   "icon": "table_rows",
   "keywords": [

--- a/src/components/EditableCellRelational.vue
+++ b/src/components/EditableCellRelational.vue
@@ -196,6 +196,8 @@ import { buildM2ASegments, isBlockedSegment, type M2ASegment } from '../utils/bu
 import { createDescribeHop } from '../utils/describeHop';
 import { resolveUserLanguage } from '../utils/resolveUserLanguage';
 import { resolveTranslationValue } from '../utils/resolveTranslationValue';
+import { renderBareTranslation } from '../utils/bareTranslationField';
+import { stripHtml } from '../utils/stripHtml';
 import { usePermissions } from '../composables/usePermissions';
 
 const { useFieldsStore, useRelationsStore, useUserStore } = useStores();
@@ -303,6 +305,21 @@ const displayValue = computed(() => {
       actualFieldKey.value,
       fieldLanguage.value ?? null,
       props.languageCodeField || 'languages_code'
+    );
+  }
+
+  // Bare `translations` column (no sub-field, no `:lang`): render the active-
+  // language row through the configured/heuristic template instead of raw JSON.
+  // (selectedLanguage is never passed to the cell, so the active language is
+  // effectively the current user's — `fieldLanguage` stays the first operand for
+  // consistency with the dotted-translations branch above.)
+  if (props.field?.meta?.special?.includes('translations') && !actualFieldKey.value.includes('.')) {
+    return renderBareTranslation(
+      props.item[actualFieldKey.value],
+      fieldLanguage.value ?? resolveUserLanguage(userStore),
+      props.languageCodeField || 'languages_code',
+      props.columnDisplays?.[storageKey.value]?.template,
+      (row, template) => stripHtml(renderTemplate(row, template))
     );
   }
 

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -303,9 +303,8 @@ import {
   getTranslationLanguageFieldPath,
 } from './composables/useTranslationConfig';
 import { sanitizeFilter } from './utils/sanitizeFilter';
-import { buildNestedM2ADeep, mergeNestedM2ADeep } from './utils/buildNestedM2ADeep';
+import { buildDeep } from './utils/buildNestedM2ADeep';
 import { buildQueryFingerprint } from './utils/buildQueryFingerprint';
-import { createDescribeHop } from './utils/describeHop';
 import { createCoalescedRunner } from './utils/coalesce';
 import { PER_PAGE_OPTIONS } from './constants/pagination';
 import { DEFAULT_LANGUAGES } from './constants/languages';
@@ -809,66 +808,12 @@ const searchFilter = computed(() =>
   })
 );
 
-// Build deep parameter for relational fields
-const deep = computed(() => {
-  const deepFields: Record<string, any> = {};
-
-  fields.value.forEach((field: string) => {
-    // Remove language suffix if present
-    const actualField = stripLanguageSuffix(field);
-
-    // Handle dot-notation relational fields (like "user_created.first_name")
-    if (actualField.includes('.')) {
-      const parts = actualField.split('.');
-      const rootField = parts[0];
-
-      // For translations, we fetch all and filter client-side
-      if (rootField === 'translations') {
-        if (!deepFields[rootField]) {
-          deepFields[rootField] = {
-            _fields: ['*'], // Get all fields including languages_code
-            _limit: -1, // Get all translations for client-side filtering
-          };
-        }
-      } else {
-        // For other relations
-        if (!deepFields[rootField]) {
-          deepFields[rootField] = {
-            _fields: ['*'],
-          };
-        }
-      }
-    } else {
-      // Handle pure relational fields (like "image_data", "status_id", etc.)
-      // Check if this field is relational by looking at field metadata
-      const fieldMeta = fieldsStore.getField(collection.value, actualField);
-
-      const special = fieldMeta?.meta?.special ?? [];
-      if (
-        special.includes('m2o') ||
-        special.includes('o2m') ||
-        special.includes('m2m') ||
-        special.includes('m2a')
-      ) {
-        if (!deepFields[actualField]) {
-          deepFields[actualField] = special.includes('m2a')
-            ? { _fields: ['*'], _limit: -1 } // fetch every polymorphic row, not just the first page
-            : { _fields: ['*'] };
-        }
-      }
-    }
-  });
-
-  // Nested to-many relations inside expanded M2A item paths (e.g.
-  // treatment.item:service.translations) are not covered by the first-level
-  // entries above and would be capped at the server's default page size.
-  mergeNestedM2ADeep(
-    deepFields,
-    buildNestedM2ADeep(fieldsWithRelational.value, createDescribeHop(fieldsStore, relationsStore))
-  );
-
-  return Object.keys(deepFields).length > 0 ? deepFields : undefined;
-});
+// Build the `deep` parameter from a single schema-driven classifier. Two field
+// lists: `fields` drives the first-level entries, `fieldsWithRelational` carries
+// the display-expanded M2A item paths for the nested entries.
+const deep = computed(() =>
+  buildDeep(fields.value, fieldsWithRelational.value, collection.value, fieldsStore, relationsStore)
+);
 
 // Initialize filter presets composable with layoutOptions
 const {
@@ -914,21 +859,8 @@ async function handleQuickFilterSaved(event: any) {
   }
 }
 
-// Setup event listeners on mount
-onMounted(() => {
-  // Load presets from layoutOptions (no localStorage needed)
-  loadPresets();
-
-  // Load initial items
-  scheduleGetItems();
-
-  // Listen for save events from actions
-  window.addEventListener('quick-filter-saved', handleQuickFilterSaved);
-});
-
-onUnmounted(() => {
-  window.removeEventListener('quick-filter-saved', handleQuickFilterSaved);
-});
+// Initial load + the quick-filter-saved listener are registered in the single
+// consolidated onMounted/onUnmounted at the end of the script.
 
 // Update manual filters when props.filter changes (from native filter interface)
 watch(
@@ -1356,16 +1288,20 @@ function handleRefreshCollectionEvent(event: any) {
 }
 
 onMounted(() => {
+  // Initial load: presets first, then items.
+  loadPresets();
+  scheduleGetItems();
+
+  // All window listeners in one place; named handlers so onUnmounted removes the
+  // SAME references (inline arrows would make the removals silent no-ops).
+  window.addEventListener('quick-filter-saved', handleQuickFilterSaved);
   window.addEventListener('directus-items-duplicated', handleItemsDuplicated);
-
-  // Listen for Directus core delete events
   window.addEventListener('items-deleted', handleItemsDeletedEvent);
-
-  // Listen for collection refresh events
   window.addEventListener('refresh-collection', handleRefreshCollectionEvent);
 });
 
 onUnmounted(() => {
+  window.removeEventListener('quick-filter-saved', handleQuickFilterSaved);
   window.removeEventListener('directus-items-duplicated', handleItemsDuplicated);
   window.removeEventListener('items-deleted', handleItemsDeletedEvent);
   window.removeEventListener('refresh-collection', handleRefreshCollectionEvent);

--- a/src/utils/bareTranslationField.ts
+++ b/src/utils/bareTranslationField.ts
@@ -1,0 +1,57 @@
+import { pickTranslationRow } from './resolveRelationalPath';
+
+/**
+ * Pick the field to display for a BARE `translations` column (one with no
+ * sub-field configured). Used after the active-language row has been selected:
+ * prefers common human-readable fields, then falls back to the first non-id,
+ * non-relational scalar on the row. The language-code field and primary key are
+ * skipped. Returns null when the row has nothing sensible to show (caller then
+ * renders an em dash instead of raw JSON).
+ */
+const PREFERRED_FIELDS = [
+  'description',
+  'title',
+  'label',
+  'name',
+  'headline',
+  'text',
+  'content',
+  'value',
+] as const;
+
+export function defaultBareTranslationField(
+  row: Record<string, unknown> | null | undefined,
+  languageCodeField: string
+): string | null {
+  if (!row) return null;
+  for (const f of PREFERRED_FIELDS) {
+    if (f in row && row[f] != null && typeof row[f] !== 'object') return f;
+  }
+  const skip = new Set(['id', languageCodeField]);
+  return (
+    Object.keys(row).find(
+      (k) => !skip.has(k) && !k.endsWith('_id') && row[k] != null && typeof row[k] !== 'object'
+    ) ?? null
+  );
+}
+
+/**
+ * Render a BARE `translations` column: pick the active-language row (falling back
+ * to the first), then render it through the configured column template, else a
+ * heuristic `{{field}}` template. `render` interpolates + strips HTML — injected
+ * so this stays pure/testable. Returns an em dash when there is no row or nothing
+ * displayable; never the raw array.
+ */
+export function renderBareTranslation(
+  rows: unknown,
+  language: string | null,
+  languageCodeField: string,
+  configuredTemplate: string | null | undefined,
+  render: (row: Record<string, unknown>, template: string) => string
+): string {
+  const row = pickTranslationRow(rows, language, languageCodeField);
+  if (!row) return '—';
+  const fallback = defaultBareTranslationField(row, languageCodeField);
+  const template = configuredTemplate || (fallback ? `{{${fallback}}}` : null);
+  return template ? render(row, template) : '—';
+}

--- a/src/utils/buildNestedM2ADeep.ts
+++ b/src/utils/buildNestedM2ADeep.ts
@@ -1,4 +1,6 @@
-import { splitPathSegments, type DescribeHop } from './resolveRelationalPath';
+import { splitPathSegments, type DescribeHop, type HopKind } from './resolveRelationalPath';
+import { createDescribeHop } from './describeHop';
+import { stripLanguageSuffix } from './displayHeuristics';
 
 /** Hop kinds whose value is an array the server pages with its default limit. */
 const TO_MANY_KINDS = new Set(['o2m', 'm2m', 'm2a', 'files', 'translations']);
@@ -71,4 +73,78 @@ export function mergeNestedM2ADeep(
     };
   }
   return deepFields;
+}
+
+/**
+ * Store shapes buildDeep needs — only what `createDescribeHop` (and the
+ * first-level `getField`) consume; mirrors describeHop.ts's private interfaces.
+ */
+interface FieldsStoreLike {
+  getField: (
+    collection: string | null,
+    field: string
+  ) => { meta?: { special?: string[] | null } | null } | null;
+}
+interface RelationsStoreLike {
+  getRelationsForField: (
+    collection: string,
+    field: string
+  ) =>
+    | Array<{
+        collection?: string;
+        field?: string;
+        related_collection?: string | null;
+        meta?: { one_field?: string | null; junction_field?: string | null } | null;
+      }>
+    | null
+    | undefined;
+}
+
+/**
+ * Map a hop kind to its `deep` entry. A first-level to-many column renders ALL
+ * its rows joined (EditableCellRelational), so it is fetched unbounded
+ * (`_limit:-1`) — capping would silently truncate the displayed list; the same
+ * policy the nested builder applies via `TO_MANY_KINDS`. Trade-off: a column on
+ * a very large o2m/m2m relation fetches every row. To-one fetches all fields;
+ * scalar/unknown (incl. an unhydrated-store throw, self-heals on recompute)
+ * gets no entry.
+ */
+function deepEntryForKind(kind: HopKind): Record<string, any> | null {
+  if (TO_MANY_KINDS.has(kind)) return { _fields: ['*'], _limit: -1 };
+  if (kind === 'm2o' || kind === 'file') return { _fields: ['*'] };
+  return null;
+}
+
+/**
+ * Build the full `deep` parameter for the items request from ONE schema-driven
+ * classifier. First-level entries (one per visible relational field, keyed by
+ * its root segment) and the nested M2A entries are both derived via
+ * `describeHop`, so there is a single source of truth for how a field maps to
+ * its `deep` shape. `fields` are the raw visible columns; `expandedFields` are
+ * the display-expanded set that carries the M2A `item:collection.path` tokens.
+ * Returns undefined when no relational field needs a deep entry.
+ */
+export function buildDeep(
+  fields: readonly string[],
+  expandedFields: readonly string[],
+  collection: string | null,
+  fieldsStore: FieldsStoreLike,
+  relationsStore: RelationsStoreLike
+): Record<string, any> | undefined {
+  const describeHop = createDescribeHop(fieldsStore, relationsStore);
+  const deepFields: Record<string, any> = {};
+
+  for (const field of fields) {
+    const actualField = stripLanguageSuffix(field);
+    // Key on the root segment: `translations.label` and `translations.title`
+    // share one `translations` deep entry.
+    const rootField = actualField.includes('.') ? actualField.split('.')[0]! : actualField;
+    if (!rootField || !collection || deepFields[rootField]) continue;
+    const entry = deepEntryForKind(describeHop(collection, rootField).kind);
+    if (entry) deepFields[rootField] = entry;
+  }
+
+  mergeNestedM2ADeep(deepFields, buildNestedM2ADeep(expandedFields, describeHop));
+
+  return Object.keys(deepFields).length > 0 ? deepFields : undefined;
 }

--- a/src/utils/resolveRelationalPath.ts
+++ b/src/utils/resolveRelationalPath.ts
@@ -118,7 +118,7 @@ export function collectTranslationLanguagePaths(
  * the detected language field), falling back to the first row when the language
  * is absent. Returns null for a non-array / empty value.
  */
-function pickTranslationRow(
+export function pickTranslationRow(
   value: unknown,
   language: string | null,
   languageField: string | null | undefined

--- a/tests/unit/utils/bareTranslationField.test.ts
+++ b/tests/unit/utils/bareTranslationField.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { defaultBareTranslationField, renderBareTranslation } from '@/utils/bareTranslationField';
+
+describe('defaultBareTranslationField', () => {
+  it('prefers description over other present fields', () => {
+    expect(
+      defaultBareTranslationField(
+        { languages_code: 'de-DE', title: 'T', description: 'D' },
+        'languages_code'
+      )
+    ).toBe('description');
+  });
+
+  it('falls through the preferred list (title when no description)', () => {
+    expect(defaultBareTranslationField({ languages_code: 'de-DE', title: 'T' }, 'languages_code')).toBe(
+      'title'
+    );
+  });
+
+  it('matches a preferred field even alongside id / *_id', () => {
+    expect(
+      defaultBareTranslationField(
+        { id: 1, languages_code: 'de-DE', service_id: 5, headline: 'H' },
+        'languages_code'
+      )
+    ).toBe('headline');
+  });
+
+  it('falls back to the first non-id scalar, skipping id and the language field', () => {
+    expect(
+      defaultBareTranslationField({ id: 1, languages_code: 'de-DE', slug: 'abc' }, 'languages_code')
+    ).toBe('slug');
+  });
+
+  it('skips *_id keys and object/relational values', () => {
+    expect(
+      defaultBareTranslationField(
+        { id: 1, languages_code: 'de-DE', parent_id: 9, nested: { a: 1 }, code: 'X' },
+        'languages_code'
+      )
+    ).toBe('code');
+  });
+
+  it('honours a non-default language-code field name', () => {
+    expect(defaultBareTranslationField({ id: 1, lang: 'de-DE', tagline: 'T' }, 'lang')).toBe('tagline');
+  });
+
+  it('returns null for null or nothing displayable', () => {
+    expect(defaultBareTranslationField(null, 'languages_code')).toBeNull();
+    expect(defaultBareTranslationField(undefined, 'languages_code')).toBeNull();
+    expect(defaultBareTranslationField({ id: 1, languages_code: 'de-DE' }, 'languages_code')).toBeNull();
+  });
+});
+
+describe('renderBareTranslation', () => {
+  const rows = [
+    { languages_code: 'en-US', description: '<p>English</p>' },
+    { languages_code: 'de-DE', description: '<p>Deutsch</p>' },
+  ];
+  // Mimics the component's render: interpolate {{key}} then strip tags.
+  const render = (row: Record<string, unknown>, tmpl: string): string =>
+    tmpl.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, k) => String(row[k] ?? '')).replace(/<[^>]+>/g, '');
+
+  it('renders the active-language row via the heuristic field', () => {
+    expect(renderBareTranslation(rows, 'de-DE', 'languages_code', undefined, render)).toBe('Deutsch');
+  });
+
+  it('falls back to the first row when the language is absent', () => {
+    expect(renderBareTranslation(rows, 'fr-FR', 'languages_code', undefined, render)).toBe('English');
+  });
+
+  it('prefers a configured template over the heuristic field', () => {
+    const r = [{ languages_code: 'de-DE', description: 'D', title: 'T' }];
+    expect(renderBareTranslation(r, 'de-DE', 'languages_code', '{{title}}', render)).toBe('T');
+  });
+
+  it('returns an em dash for a non-array or empty value', () => {
+    expect(renderBareTranslation(null, 'de-DE', 'languages_code', undefined, render)).toBe('—');
+    expect(renderBareTranslation([], 'de-DE', 'languages_code', undefined, render)).toBe('—');
+  });
+
+  it('returns an em dash when the row has nothing displayable', () => {
+    expect(
+      renderBareTranslation([{ languages_code: 'de-DE', id: 1 }], 'de-DE', 'languages_code', undefined, render)
+    ).toBe('—');
+  });
+});

--- a/tests/unit/utils/buildNestedM2ADeep.test.ts
+++ b/tests/unit/utils/buildNestedM2ADeep.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildNestedM2ADeep, mergeNestedM2ADeep } from '@/utils/buildNestedM2ADeep';
+import { buildNestedM2ADeep, mergeNestedM2ADeep, buildDeep } from '@/utils/buildNestedM2ADeep';
 import type { DescribeHop, HopInfo } from '@/utils/resolveRelationalPath';
 import { buildM2AFieldPath } from '@/utils/displayHeuristics';
 
@@ -172,5 +172,157 @@ describe('mergeNestedM2ADeep', () => {
     const deepFields: Record<string, any> = { treatment: { _fields: ['*'], _limit: -1 } };
     mergeNestedM2ADeep(deepFields, {});
     expect(deepFields).toEqual({ treatment: { _fields: ['*'], _limit: -1 } });
+  });
+});
+
+describe('buildDeep', () => {
+  // Mock the two stores buildDeep feeds into createDescribeHop. The first-level
+  // classifier only needs `meta.special`; the nested builder needs the relation
+  // rows for any M2A item path. Keyed by `${collection}.${field}`.
+  const makeStores = (
+    fieldsMap: Record<string, { special?: string[] }>,
+    relationsMap: Record<string, any[]> = {}
+  ) => ({
+    fieldsStore: {
+      getField: (c: string | null, f: string) =>
+        fieldsMap[`${c}.${f}`] ? { meta: { special: fieldsMap[`${c}.${f}`]!.special ?? [] } } : null,
+    },
+    relationsStore: {
+      getRelationsForField: (c: string, f: string) => relationsMap[`${c}.${f}`] ?? [],
+    },
+  });
+
+  it('emits _fields + _limit:-1 for a dotted translations root', () => {
+    const { fieldsStore, relationsStore } = makeStores({ 'orders.translations': { special: ['translations'] } });
+    expect(buildDeep(['translations.description'], [], 'orders', fieldsStore, relationsStore)).toEqual({
+      translations: { _fields: ['*'], _limit: -1 },
+    });
+  });
+
+  it('fetches all fields without _limit for a to-one m2o root', () => {
+    const { fieldsStore, relationsStore } = makeStores({ 'orders.user_created': { special: ['m2o'] } });
+    expect(buildDeep(['user_created.first_name'], [], 'orders', fieldsStore, relationsStore)).toEqual({
+      user_created: { _fields: ['*'] },
+    });
+  });
+
+  it('unbounds a to-many m2m/o2m/files root (one source of truth with the nested builder)', () => {
+    const { fieldsStore, relationsStore } = makeStores({
+      'orders.tags': { special: ['m2m'] },
+      'orders.lines': { special: ['o2m'] },
+      'orders.attachments': { special: ['files'] },
+    });
+    expect(
+      buildDeep(['tags.tag_id.name', 'lines.qty', 'attachments.file_id'], [], 'orders', fieldsStore, relationsStore)
+    ).toEqual({
+      tags: { _fields: ['*'], _limit: -1 },
+      lines: { _fields: ['*'], _limit: -1 },
+      attachments: { _fields: ['*'], _limit: -1 },
+    });
+  });
+
+  it('drops a dotted non-relational root (no deep entry)', () => {
+    const { fieldsStore, relationsStore } = makeStores({ 'orders.meta_json': { special: [] } });
+    expect(buildDeep(['meta_json.foo'], [], 'orders', fieldsStore, relationsStore)).toBeUndefined();
+  });
+
+  it('treats a dotted file root as to-one (all fields, no _limit)', () => {
+    const { fieldsStore, relationsStore } = makeStores({ 'orders.cover': { special: ['file'] } });
+    expect(buildDeep(['cover.title'], [], 'orders', fieldsStore, relationsStore)).toEqual({
+      cover: { _fields: ['*'] },
+    });
+  });
+
+  it('classifies bare relational fields by kind', () => {
+    const { fieldsStore, relationsStore } = makeStores({
+      'orders.treatment': { special: ['m2a'] },
+      'orders.author': { special: ['m2o'] },
+      'orders.lines': { special: ['o2m'] },
+      'orders.translations': { special: ['translations'] },
+      'orders.cover': { special: ['file'] },
+      'orders.gallery': { special: ['files'] },
+    });
+    expect(
+      buildDeep(
+        ['treatment', 'author', 'lines', 'translations', 'cover', 'gallery'],
+        [],
+        'orders',
+        fieldsStore,
+        relationsStore
+      )
+    ).toEqual({
+      treatment: { _fields: ['*'], _limit: -1 },
+      author: { _fields: ['*'] },
+      lines: { _fields: ['*'], _limit: -1 },
+      translations: { _fields: ['*'], _limit: -1 },
+      cover: { _fields: ['*'] },
+      gallery: { _fields: ['*'], _limit: -1 },
+    });
+  });
+
+  it('skips a bare scalar field', () => {
+    const { fieldsStore, relationsStore } = makeStores({ 'orders.code': { special: [] } });
+    expect(buildDeep(['code'], [], 'orders', fieldsStore, relationsStore)).toBeUndefined();
+  });
+
+  it('strips the language suffix and dedupes dotted fields onto the root key', () => {
+    const { fieldsStore, relationsStore } = makeStores({ 'orders.translations': { special: ['translations'] } });
+    expect(
+      buildDeep(
+        ['translations.description:de-DE', 'translations.title:en-US'],
+        [],
+        'orders',
+        fieldsStore,
+        relationsStore
+      )
+    ).toEqual({ translations: { _fields: ['*'], _limit: -1 } });
+  });
+
+  it('returns undefined for empty input or a null collection', () => {
+    const { fieldsStore, relationsStore } = makeStores({ 'orders.treatment': { special: ['m2a'] } });
+    expect(buildDeep([], [], 'orders', fieldsStore, relationsStore)).toBeUndefined();
+    expect(buildDeep(['treatment'], [], null, fieldsStore, relationsStore)).toBeUndefined();
+  });
+
+  it('merges nested M2A deep from expandedFields (two distinct field lists)', () => {
+    const { fieldsStore, relationsStore } = makeStores(
+      { 'orders.treatment': { special: ['m2a'] }, 'service.translations': { special: ['translations'] } },
+      {
+        'service.translations': [
+          {
+            collection: 'service_translations',
+            field: 'service_id',
+            related_collection: 'service',
+            meta: { one_field: 'translations', junction_field: 'languages_code' },
+          },
+        ],
+      }
+    );
+    expect(
+      buildDeep(['treatment'], ['treatment.item:service.translations.label'], 'orders', fieldsStore, relationsStore)
+    ).toEqual({
+      treatment: { _fields: ['*'], _limit: -1, 'item:service': { translations: { _limit: -1 } } },
+    });
+  });
+
+  it('applies the M2A merge default when the root is only in expandedFields', () => {
+    const { fieldsStore, relationsStore } = makeStores(
+      { 'service.translations': { special: ['translations'] } },
+      {
+        'service.translations': [
+          {
+            collection: 'service_translations',
+            field: 'service_id',
+            related_collection: 'service',
+            meta: { one_field: 'translations', junction_field: 'languages_code' },
+          },
+        ],
+      }
+    );
+    expect(
+      buildDeep([], ['treatment.item:service.translations.label'], 'orders', fieldsStore, relationsStore)
+    ).toEqual({
+      treatment: { _fields: ['*'], _limit: -1, 'item:service': { translations: { _limit: -1 } } },
+    });
   });
 });

--- a/tests/unit/utils/resolveRelationalPath.test.ts
+++ b/tests/unit/utils/resolveRelationalPath.test.ts
@@ -3,6 +3,7 @@ import {
   resolveRelationalPath,
   collectTranslationLanguagePaths,
   splitPathSegments,
+  pickTranslationRow,
   type HopInfo,
 } from '@/utils/resolveRelationalPath';
 
@@ -183,5 +184,32 @@ describe('splitPathSegments', () => {
   it('returns [] for an empty or all-virtual path', () => {
     expect(splitPathSegments('')).toEqual([]);
     expect(splitPathSegments('$thumbnail')).toEqual([]);
+  });
+});
+
+describe('pickTranslationRow', () => {
+  const rows = [
+    { languages_code: 'en-US', label: 'EN' },
+    { languages_code: 'de-DE', label: 'DE' },
+  ];
+
+  it('returns the row matching the active language', () => {
+    expect(pickTranslationRow(rows, 'de-DE', 'languages_code')).toBe(rows[1]);
+  });
+
+  it('falls back to the first row when the language is absent or null', () => {
+    expect(pickTranslationRow(rows, 'fr-FR', 'languages_code')).toBe(rows[0]);
+    expect(pickTranslationRow(rows, null, 'languages_code')).toBe(rows[0]);
+  });
+
+  it('honours a non-default language field', () => {
+    const r = [{ lang: 'de-DE', label: 'DE' }];
+    expect(pickTranslationRow(r, 'de-DE', 'lang')).toBe(r[0]);
+  });
+
+  it('returns null for a non-array, empty, or non-object first element', () => {
+    expect(pickTranslationRow(null, 'de-DE', 'languages_code')).toBeNull();
+    expect(pickTranslationRow([], 'de-DE', 'languages_code')).toBeNull();
+    expect(pickTranslationRow(['scalar'], null, 'languages_code')).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #70.

Consolidates the `super-table.vue` orchestrator and unifies `deep`-query construction onto a single schema-driven classifier (`describeHop`), plus a folded-in display improvement. Released as **0.6.2** (patch on the 0.6.x line — a deliberate, contained behavior change; see note below).

## Changes

**Refactor — one schema-driven deep classifier (`buildDeep`)**
- First-level and nested `deep` entries are both derived via `describeHop`, removing the ad-hoc `special.includes(...)` first-level branch from the SFC. `super-table.vue` shrinks ~98 lines.

**Behavior change — to-many fetched completely**
- First-level `o2m`/`m2m`/`files` columns (and bare `translations`) now fetch unbounded (`deep[<field>][_limit]=-1`), consistent with the nested-M2A policy. Previously they were capped at the server default page size (silently truncating the comma-joined list) or not fetched. Trade-off: a column on a very large to-many relation fetches every row — the inherent cost of displaying it fully. Verified live that first-level to-many columns render ALL elements joined (e.g. `tags` → "Urgent1, VIP2"), so the unbounded fetch is required for completeness, not cosmetic.

**Lifecycle consolidation**
- The two `onMounted`/`onUnmounted` blocks are merged into one auditable pair (4 listeners add/remove symmetric; initial `loadPresets`/`scheduleGetItems` preserved).

**Feature — bare `translations` columns render the active-language value**
- Instead of raw JSON, a bare `translations` column renders the active-language row (current user's language → first-row fallback) through its configured template or a heuristic field (`description`/`title`/…), HTML-stripped. Pure, testable `renderBareTranslation` reusing the exported `pickTranslationRow` + `resolveUserLanguage`.

## Verification
- **Unit:** 431/431 (24 added). `vue-tsc`, ESLint `--max-warnings=0`, Prettier — all green.
- **Live Playwright (comprehensive):** 13 collections smoke (all render, 0 console errors); m2m-unbounded confirmed live (`deep[tags][_limit]=-1`); core interactions (search, pagination→page 2 single-fetch, bookmarks #60/#65 repro presets); full M2A/translation regression identical to v0.6.1; bare-translations column shows readable descriptions, not JSON.
- **Two adversarial review rounds:** deep/lifecycle (the "use `_limit:1`" finding was refuted live — it would break m2m/o2m column display) and the bare-translation render branch (test-gap auflagen closed by extracting `renderBareTranslation` + direct `pickTranslationRow` tests).

## Note on versioning
Strict SemVer would call the behavior change a minor; on this 0.x project it ships as a **patch (0.6.2)** at maintainer discretion.

## Test plan
- [x] Unit suite green (incl. new buildDeep / bareTranslation / pickTranslationRow tests)
- [x] type-check / lint / format green
- [x] 13-collection smoke, 0 console errors
- [x] to-many unbounded deep param confirmed live; columns render completely
- [x] M2A/translation feature regression identical to v0.6.1
- [x] bare translations renders active-language value, not raw JSON
- [x] lifecycle merged (1 onMounted/onUnmounted, 4/4 listeners)