### PR TITLE
feat: open rows in a new tab on Ctrl/Cmd+click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the Super Layout Table Extension will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.7.0 — Open rows in a new tab (Ctrl/Cmd+click)
+
+Implements #72. Table rows can be opened in a new browser tab, matching the
+"open in new tab" behavior users expect from links.
+
+### Added
+- **Ctrl/Cmd+click opens the row in a new tab.** Ctrl+click (Windows/Linux) or
+  Cmd+click (macOS) on a row opens its detail page in a new tab; a normal
+  left-click keeps the existing behavior (navigate in the same tab, or edit when
+  edit mode is on). Because `v-table` only emits `click:row` while `clickable`
+  (which the layout disables in edit mode), modifier-clicks are intercepted in the
+  capture phase and stopped before the cell editor or in-tab navigation react — so
+  it works in both normal and edit mode without opening the inline editor.
+
+### Internal
+- Detail-route construction is shared via `getItemRoute` / `getItemRouteOrWarn`
+  (a consistent "missing primary key" warning for both the row-click and
+  modifier-click paths). The new tab opens with `noopener,noreferrer`, and the
+  primary key is URL-encoded. `vue-tsc`, ESLint and Prettier green; verified live
+  (edit mode on) that Ctrl/Cmd+click opens the correct row id in a new tab while a
+  plain click still opens the inline editor.
+
 ## v0.6.2 — Unified deep-build, lifecycle consolidation & bare-translation display
 
 Follow-up to v0.6.1 (#70). Consolidates the `super-table.vue` orchestrator and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Super Layout Table Extension will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.7.0 — Open rows in a new tab (Ctrl/Cmd+click)
+## v0.6.3 — Open rows in a new tab (Ctrl/Cmd+click)
 
 Implements #72. Table rows can be opened in a new browser tab, matching the
 "open in new tab" behavior users expect from links.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Super Layout Table Extension for Directus
 
+![Version](https://img.shields.io/github/v/release/smartlabsAT/directus-super-table)
+![License](https://img.shields.io/badge/license-MIT-green)
+![npm downloads](https://img.shields.io/npm/dt/directus-extension-super-table)
 ![Quality Checks](https://github.com/smartlabsAT/directus-super-table/workflows/Quality%20Checks/badge.svg)
 ![TypeScript](https://img.shields.io/badge/TypeScript-Strict-blue)
 ![ESLint](https://img.shields.io/badge/ESLint-0%20errors-brightgreen)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-super-table",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "A powerful and feature-rich table layout extension for Directus 11+ with inline editing, quick filters, and manual sorting",
   "icon": "table_rows",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-super-table",
-  "version": "0.7.0",
+  "version": "0.6.3",
   "description": "A powerful and feature-rich table layout extension for Directus 11+ with inline editing, quick filters, and manual sorting",
   "icon": "table_rows",
   "keywords": [

--- a/src/super-table.vue
+++ b/src/super-table.vue
@@ -1,6 +1,6 @@
 <!-- super-layout-table with full relational field support and filter presets -->
 <template>
-  <div class="super-layout-table">
+  <div class="super-layout-table" @click.capture="openRowInNewTabOnModifier">
     <!-- Top Bar with Search and Filters -->
     <div class="table-toolbar" v-if="showToolbar">
       <div class="toolbar-content">
@@ -1153,21 +1153,30 @@ function toPage(newPage: number) {
   page.value = newPage;
 }
 
-function editItem(item: Item) {
+function getItemRoute(item: Item): string | null {
   // Get the primary key field name directly (no .value needed as per Directus pattern)
   const pkField = getPrimaryKeyFieldName();
   const primaryKey = item[pkField];
+  if (!primaryKey) return null;
+  return `/content/${collection.value}/${encodeURIComponent(String(primaryKey))}`;
+}
 
-  if (!primaryKey) {
+// Resolve the detail route, or surface a warning when the primary key is missing
+function getItemRouteOrWarn(item: Item): string | null {
+  const route = getItemRoute(item);
+  if (!route) {
     notificationsStore.add({
       type: 'warning',
       title: 'Navigation Error',
       text: `Could not find primary key in item`,
     });
-    return;
   }
+  return route;
+}
 
-  router.push(`/content/${collection.value}/${primaryKey}`);
+function editItem(item: Item) {
+  const route = getItemRouteOrWarn(item);
+  if (route) router.push(route);
 }
 
 // Helper function to move item in array (exact Directus implementation)
@@ -1258,6 +1267,32 @@ function handleTableRowClick({ item, event }: { item: Item; event: MouseEvent })
 
   // Navigate to detail page
   editItem(item);
+}
+
+// v-table suppresses click:row in edit mode; intercept modifier-clicks in the capture phase to open a new tab in both modes
+function openRowInNewTabOnModifier(event: MouseEvent) {
+  if (!event.ctrlKey && !event.metaKey) return;
+  const target = event.target as HTMLElement | null;
+  if (
+    !target ||
+    target.closest('button') ||
+    target.closest('.v-checkbox') ||
+    target.closest('input') ||
+    target.closest('textarea') ||
+    target.closest('.v-select')
+  ) {
+    return;
+  }
+  const row = target.closest('tbody tr');
+  const tbody = row?.parentElement;
+  if (!row || !tbody) return;
+  const item = items.value[Array.from(tbody.children).indexOf(row)];
+  if (!item) return;
+  const route = getItemRouteOrWarn(item);
+  if (!route) return;
+  window.open(router.resolve(route).href, '_blank', 'noopener,noreferrer');
+  event.preventDefault();
+  event.stopPropagation();
 }
 
 // Watch for search changes


### PR DESCRIPTION
> **Release:** this PR also bumps the version to **0.6.3** (patch — small additive change, consistent with v0.6.2 also shipping as a patch) and adds the matching `CHANGELOG.md` entry.

## What & why

Implements #72 — table rows can now be opened in a new browser tab via **Ctrl+click** (Windows/Linux) / **Cmd+click** (macOS). A normal left-click keeps its current behavior (navigate in the same tab, or edit in edit mode).

## Root cause that made this non-trivial

The layout persists an **edit mode** (`layoutOptions.editMode`). In edit mode the table binds `:clickable="!editMode"` = `false`, and Directus' `v-table` only emits `click:row` when `clickable` is true. So in edit mode **no row-click event fires at all** — which is why a naive `@click:row` modifier check never runs for users who keep edit mode on.

## Implementation

- Modifier-clicks are intercepted on the layout root in the **capture phase** (`@click.capture`), so they work in **both** normal and edit mode and are stopped before the cell editor or in-tab navigation react (no editor popup, no double navigation).
- Route resolution is shared via `getItemRoute` / `getItemRouteOrWarn` (consistent "missing primary key" warning for both click paths).
- New tab opens with `noopener,noreferrer`; the primary key is URL-encoded.

## Verification (Playwright, against a live instance with edit mode on)

| Action | Result |
|---|---|
| Cmd+click (row id 221) | opens `…/content_headline/221`, `target=_blank`, `features=noopener,noreferrer`; editor does **not** open |
| Cmd+click (row id 224) | opens `…/224` — correct, different id |
| Ctrl+click | new tab; editor does not open |
| Plain click | no new tab; editor still opens (edit mode intact) |

`vue-tsc`, ESLint (`--max-warnings=0`) and Prettier all pass.

Closes #72